### PR TITLE
Serve CSS with https to Fix HTTPS Site

### DIFF
--- a/couscous.yml
+++ b/couscous.yml
@@ -7,7 +7,7 @@ template:
     index: README.md
 
 # Base URL of the published website
-baseUrl: http://openfn.github.io/docs/
+baseUrl: https://openfn.github.io/docs/
 
 exclude:
     - job-library

--- a/page-template/default.twig
+++ b/page-template/default.twig
@@ -53,7 +53,7 @@
       <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>
       <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
       <script src="//yastatic.net/highlightjs/8.2/highlight.min.js"></script>
-      <script src="http://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.1.1/anchor.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/3.1.1/anchor.js"></script>
       <script src="{{ baseUrl }}/toc.min.js"></script>
 
       <script>


### PR DESCRIPTION
Hi there,

The docs site uses `http://openfn.github.io/docs/` by default, but github.io's wildcard cert _does_ make `https://openfn.github.io/docs/` available. The HTTPS site doesn't load CSS properly.

This PR changes the baseUrl to `https://openfn.github.io/docs/`, as well as switching the CloudFlare AnchorJS link to HTTPS, as they just redirect from http -> https anyway over there.

These changes shouldn't break the http site -- visitors to that will just load some CSS and JS over HTTPS instead of over http -- and they _will_ fix the https site, which browsers will refuse to load the CSS for as it's over http.

(If you're not ready to change to https completely, the "better" way to do this would be to use "//" in the `<link>`s for CSS, but that requires some more fiddling.)

Thanks!