### PR TITLE
Add docs for adaptor custom install

### DIFF
--- a/docs/build/adaptors.md
+++ b/docs/build/adaptors.md
@@ -43,28 +43,25 @@ Most of our adaptors are also available on
 
 ![Adaptors list in npm](/img/adaptor_npm.png)
 
----
+:::info
 
-**NOTE**
-
-When using the [platform](https://openfn.org/), you can install an
-**unreleased** `adaptor version` from
-[npm](https://www.npmjs.com/search?q=%40openfn). To install an **unreleased
-adaptor version**, simply click on the _cloud download icon_ next to the adaptor
-version dropdown list. In the **Select Unreleased Adaptor** dialog box, enter
-the `adaptor name`(e.g. `dhis2` for `language-dhis2`) and the corresponding
-`version number`(e.g. `v2.3.4`), as listed on
-[npmjs](https://www.npmjs.com/search?q=%40openfn), for the adaptor of your
-choice. [OpenFn](https://openfn.org/) will then attempt to install the selected
-**unreleased adaptor version**, and the adaptor can then be used to run the
-specified job. Also note that, after this custom installation of the adaptor,
-[OpenFn](https://openfn.org/) will not add this **unreleased adaptor version**
-to the dropdown list of available adaptors in
+When using the [platform](https://openfn.org/), you can install **adaptors that
+are not part of the recommended adaptors picklist** from
+[npm](https://www.npmjs.com/search?q=%40openfn). To install such an adaptor,
+simply click on the _cloud download icon_ next to the adaptor version picklist.
+In the **Select Unreleased Adaptor** dialog box, enter the `adaptor name`(e.g.
+`dhis2` for `language-dhis2`) and the corresponding `version number`(e.g.
+`v2.3.4`), as listed on [npmjs](https://www.npmjs.com/search?q=%40openfn), for
+the adaptor of your choice. [OpenFn](https://openfn.org/) will then attempt to
+install the selected **adaptor version**, and the adaptor can then be used to
+run the specified job. Also note that, after this custom installation of the
+adaptor, [OpenFn](https://openfn.org/) will not add this **adaptor version** to
+the picklist of recommended adaptors in
 [JobStudio](https://docs.openfn.org/documentation/jobs/job-studio), but you are
 guaranteed that the adaptor will be available to use in any of your jobs as long
 as you specify it via the **Select Unreleased Adaptor** dialog.
 
----
+:::
 
 ## Developing an adaptor
 

--- a/docs/build/adaptors.md
+++ b/docs/build/adaptors.md
@@ -43,6 +43,29 @@ Most of our adaptors are also available on
 
 ![Adaptors list in npm](/img/adaptor_npm.png)
 
+---
+
+**NOTE**
+
+When using the [platform](https://openfn.org/), you can install an
+**unreleased** `adaptor version` from
+[npm](https://www.npmjs.com/search?q=%40openfn). To install an **unreleased
+adaptor version**, simply click on the _cloud download icon_ next to the adaptor
+version dropdown list. In the **Select Unreleased Adaptor** dialog box, enter
+the `adaptor name`(e.g. `dhis2` for `language-dhis2`) and the corresponding
+`version number`(e.g. `v2.3.4`), as listed on
+[npmjs](https://www.npmjs.com/search?q=%40openfn), for the adaptor of your
+choice. [OpenFn](https://openfn.org/) will then attempt to install the selected
+**unreleased adaptor version**, and the adaptor can then be used to run the
+specified job. Also note that, after this custom installation of the adaptor,
+[OpenFn](https://openfn.org/) will not add this **unreleased adaptor version**
+to the dropdown list of available adaptors in
+[JobStudio](https://docs.openfn.org/documentation/jobs/job-studio), but you are
+guaranteed that the adaptor will be available to use in any of your jobs as long
+as you specify it via the **Select Unreleased Adaptor** dialog.
+
+---
+
 ## Developing an adaptor
 
 You can develop a new adaptor from scratch or extend an existing one.

--- a/docs/build/adaptors.md
+++ b/docs/build/adaptors.md
@@ -43,27 +43,27 @@ Most of our adaptors are also available on
 
 ![Adaptors list in npm](/img/adaptor_npm.png)
 
-:::info
+#### Install on platform via npm
 
-When using the [platform](https://openfn.org/), you can install **adaptors that
-are not part of the recommended adaptors picklist** from
-[npm](https://www.npmjs.com/search?q=%40openfn). To install such an adaptor,
-simply click on the _cloud download icon_ next to the adaptor version picklist.
-In the **Select Unreleased Adaptor** dialog box, enter the `adaptor name`(e.g.
-`dhis2` for `language-dhis2`) and the corresponding `version number`(e.g.
-`v2.3.4`), as listed on [npmjs](https://www.npmjs.com/search?q=%40openfn), for
-the adaptor of your choice. [OpenFn](https://openfn.org/) will then attempt to
-install the selected **adaptor version**, and the adaptor can then be used to
-run the specified job. Also note that, after this custom installation of the
-adaptor, [OpenFn](https://openfn.org/) will not add this **adaptor version** to
-the picklist of recommended adaptors in
+When using `platform`, you can install adaptors that are not part of the
+recommended adaptors picklist directly from
+[npm](https://www.npmjs.com/search?q=%40openfn).
+
+To install from npm, click on the _cloud download icon_ next to the adaptor
+version picklist. In the **Select Unreleased Adaptor** dialog box, enter the
+`adaptor name`(e.g. `dhis2` for `language-dhis2`) and the corresponding
+`version number`(e.g. `v2.3.4`), as listed on
+[npmjs](https://www.npmjs.com/search?q=%40openfn), for the adaptor of your
+choice. The platform will attempt to install the selected adaptor version it can
+be used to run the specified job.
+
+Note that, after this custom installation of the adaptor, `platform` will not
+add this adaptor version to the picklist of recommended adaptors in
 [JobStudio](https://docs.openfn.org/documentation/jobs/job-studio), but you are
 guaranteed that the adaptor will be available to use in any of your jobs as long
 as you specify it via the **Select Unreleased Adaptor** dialog.
 
-:::
-
-## Developing an adaptor
+## Developing adaptors
 
 You can develop a new adaptor from scratch or extend an existing one.
 

--- a/docs/build/jobs.md
+++ b/docs/build/jobs.md
@@ -82,28 +82,8 @@ failing, but an upgrade from `3.y.z` to `4.y.z` may—in SEMVER _major_ upgrades
 (those that change the first number in the `x.y.z` version number) have
 "breaking" or "non-backwards compatible" changes.
 
----
-
-**NOTE**
-
-When using the [platform](https://openfn.org/), you can install an
-**unreleased** `adaptor version` from
-[npm](https://www.npmjs.com/search?q=%40openfn). To install an **unreleased
-adaptor version**, simply click on the _cloud download icon_ next to the adaptor
-version dropdown list. In the **Select Unreleased Adaptor** dialog box, enter
-the `adaptor name`(e.g. `dhis2` for `language-dhis2`) and the corresponding
-`version number`(e.g. `v2.3.4`), as listed on
-[npmjs](https://www.npmjs.com/search?q=%40openfn), for the adaptor of your
-choice. [OpenFn](https://openfn.org/) will then attempt to install the selected
-**unreleased adaptor version**, and the adaptor can then be used to run the
-specified job. Also note that, after this custom installation of the adaptor,
-[OpenFn](https://openfn.org/) will not add this **unreleased adaptor version**
-to the dropdown list of available adaptors in
-[JobStudio](https://docs.openfn.org/documentation/jobs/job-studio), but you are
-guaranteed that the adaptor will be available to use in any of your jobs as long
-as you specify it via the **Select Unreleased Adaptor** dialog.
-
----
+See [this section](./adaptors#on-npm) to learn how to install an adaptor from
+`npm`
 
 ## Composing job expressions
 

--- a/docs/build/jobs.md
+++ b/docs/build/jobs.md
@@ -82,6 +82,29 @@ failing, but an upgrade from `3.y.z` to `4.y.z` may—in SEMVER _major_ upgrades
 (those that change the first number in the `x.y.z` version number) have
 "breaking" or "non-backwards compatible" changes.
 
+---
+
+**NOTE**
+
+When using the [platform](https://openfn.org/), you can install an
+**unreleased** `adaptor version` from
+[npm](https://www.npmjs.com/search?q=%40openfn). To install an **unreleased
+adaptor version**, simply click on the _cloud download icon_ next to the adaptor
+version dropdown list. In the **Select Unreleased Adaptor** dialog box, enter
+the `adaptor name`(e.g. `dhis2` for `language-dhis2`) and the corresponding
+`version number`(e.g. `v2.3.4`), as listed on
+[npmjs](https://www.npmjs.com/search?q=%40openfn), for the adaptor of your
+choice. [OpenFn](https://openfn.org/) will then attempt to install the selected
+**unreleased adaptor version**, and the adaptor can then be used to run the
+specified job. Also note that, after this custom installation of the adaptor,
+[OpenFn](https://openfn.org/) will not add this **unreleased adaptor version**
+to the dropdown list of available adaptors in
+[JobStudio](https://docs.openfn.org/documentation/jobs/job-studio), but you are
+guaranteed that the adaptor will be available to use in any of your jobs as long
+as you specify it via the **Select Unreleased Adaptor** dialog.
+
+---
+
 ## Composing job expressions
 
 In most cases, a job expression is a series of `create` or `upsert` actions that
@@ -105,8 +128,8 @@ create(
 
 That would create a new `Patient__c` in some other system. The patient's `Name`
 will be determined by the triggering message (the value inside `form.surname`,
-specifically) and the patient's `Is_Enrolled__c` will _always_ be `true`. See how we hard
-coded it?
+specifically) and the patient's `Is_Enrolled__c` will _always_ be `true`. See
+how we hard coded it?
 
 What you see above is OpenFn's own syntax, and you've got access to dozens of
 common "helper functions" like `dataValue(path)` and destination specific

--- a/docs/build/jobs.md
+++ b/docs/build/jobs.md
@@ -22,9 +22,10 @@ Here, we'll focus on the expression.
 
 ### Adaptors
 
-We've got a whole section on creating new [Adaptors](./adaptors), but the
-critical thing to be aware of when writing a job is that you've got to choose an
-**adaptor**, and an **adaptor version**.
+We've got a whole section on creating new
+[Adaptors](/documentation/build/adaptors), but the critical thing to be aware of
+when writing a job is that you've got to choose an **adaptor**, and an **adaptor
+version**.
 
 All of the discussion below of helper functions like `create` or `findPatient`
 requires some understanding of adaptors. When you run a job, you're borrowing a
@@ -82,8 +83,12 @@ failing, but an upgrade from `3.y.z` to `4.y.z` may—in SEMVER _major_ upgrades
 (those that change the first number in the `x.y.z` version number) have
 "breaking" or "non-backwards compatible" changes.
 
-See [this section](./adaptors#on-npm) to learn how to install an adaptor from
-`npm`
+:::note
+
+See [the npm section](/documentation/build/adaptors#install-on-platform-via-npm) on the adaptors
+docs page to learn how to install an adaptor from `npm` while using `platform`.
+
+:::
 
 ## Composing job expressions
 

--- a/docs/deploy/options.md
+++ b/docs/deploy/options.md
@@ -31,7 +31,7 @@ can build her project using OpenFn's enterprise platform, or using components of
 the open source integration toolkit. A user may then choose to deploy the
 project initially on the platform and later migrate to her own servers when
 doing so makes sense. The good news is that OpenFn project
-[portability](./portability.md) will make these transitions easy. You will have
+[portability](/portability.md) will make these transitions easy. You will have
 full control and ownership of your integration project regardless of the
 deployment pathway you pursue.
 


### PR DESCRIPTION
This PR adds a **note** to the **adaptors** pages describing how to install a custom adaptor version from `npm`.