### PR TITLE
remove `//` in configuration schema description

### DIFF
--- a/generate-adaptors/index.js
+++ b/generate-adaptors/index.js
@@ -106,7 +106,7 @@ const sampleConfiguration = json => {
   const conf = {};
   if (properties) {
     Object.keys(properties).forEach((key, index) => {
-      conf[key] = `//${properties[key]['description']}`;
+      conf[key] = `${properties[key]['description']}`;
 
       return conf;
     });


### PR DESCRIPTION
#### Description
remove `//` in the description of the adaptor configuration 