### PR TITLE
update try out section on the about lightning page

### DIFF
--- a/blog/2023-04-13-lightning-beta.md
+++ b/blog/2023-04-13-lightning-beta.md
@@ -43,7 +43,7 @@ out our [user test](/blog#take-10-minutes-to-carry-out-our-user-test) (~10
 minutes) and adding your questions and comments to the Lightning thread on our
 [community forum](https://community.openfn.org/t/the-lightning-beta/297).
 
-## Take 10 minutes to carry out our user test
+## Take 15 minutes to carry out our user test
 
 Get your thinking hat on! We need you to click around OpenFn Lightning and
 figure out how it works.

--- a/docs/about-lightning.md
+++ b/docs/about-lightning.md
@@ -106,7 +106,7 @@ You have 3 options for exploring OpenFn/Lightning:
 2. To get your own account and start building non-production workflows, register for an account at [app.openfn.org](https://app.openfn.org/).
 3. To install and run Lightning locally follow the instructions in the [github README](https://github.com/OpenFn/Lightning).
 
-Go through the [self-paced user interview](http://localhost:3000/blog/2023/04/13/lightning-beta#take-10-minutes-to-carry-out-our-user-test) to learn how OpenFn Lightning works _and_ help us out with feedback in just 15 minutes. 
+Go through the [self-paced user interview](/blog/2023/04/13/lightning-beta#take-15-minutes-to-carry-out-our-user-test) to learn how OpenFn Lightning works _and_ help us out with feedback in just 15 minutes. 
 
 ## Guiding principles
 

--- a/docs/about-lightning.md
+++ b/docs/about-lightning.md
@@ -99,12 +99,14 @@ Lightning is still in Beta.
 
 :::
 
-Log into our demo account with username: `demo@openfn.org` password:
-`welcome123` or register for an account on
-[app.openfn.org](https://app.openfn.org/).
+You have 3 options for exploring OpenFn/Lightning:
 
-Go through the [quick-start guide](/documentation/build/lightning-quick-start)
-to learn how it works.
+1. For quick viewing, visit [demo.openfn.org](https://demo.openfn.org/) and log into our demo account with username: `demo@openfn.org` password:
+`welcome123`. (NOTE that this site refreshes every 24 hours)
+2. To get your own account and start building non-production workflows, register for an account at [app.openfn.org](https://app.openfn.org/).
+3. To install and run Lightning locally follow the instructions in the [github README](https://github.com/OpenFn/Lightning).
+
+Go through the [self-paced user interview](http://localhost:3000/blog/2023/04/13/lightning-beta#take-10-minutes-to-carry-out-our-user-test) to learn how OpenFn Lightning works _and_ help us out with feedback in just 15 minutes. 
 
 ## Guiding principles
 

--- a/docs/about-lightning.md
+++ b/docs/about-lightning.md
@@ -102,7 +102,7 @@ Lightning is still in Beta.
 You have 3 options for exploring OpenFn/Lightning:
 
 1. For quick viewing, visit [demo.openfn.org](https://demo.openfn.org/) and log into our demo account with username: `demo@openfn.org` password:
-`welcome123`. (NOTE that this site refreshes every 24 hours)
+`welcome123`. (NOTE that any changes made here are lost when the demo resets every 24 hours. I.e., don't build things you'd like to keep.)
 2. To get your own account and start building non-production workflows, register for an account at [app.openfn.org](https://app.openfn.org/).
 3. To install and run Lightning locally follow the instructions in the [github README](https://github.com/OpenFn/Lightning).
 


### PR DESCRIPTION
<img width="692" alt="Screenshot 2023-05-04 at 10 41 08" src="https://user-images.githubusercontent.com/36554605/236145162-69ae3f95-4c10-47dc-9345-fa0de82ff592.png">

- update the try out Lightning section to add link to demo and link to the self-paced interview
- change self-paced user interview time estimate to 15 instead of 10 minutes