### PR TITLE
update about-lightning page on v1 docs

### DIFF
--- a/versioned_docs/version-legacy/about-lightning.md
+++ b/versioned_docs/version-legacy/about-lightning.md
@@ -98,7 +98,7 @@ _You can follow our progress and track delivered features in our
 
 :::danger Please note
 
-Lightning is still in Beta.
+Lightning is still in Beta. Full release planned for Q4 2023.
 
 :::
 
@@ -377,11 +377,11 @@ features in our roadmap (we’re still in beta).
 
 Later: nothing - if a feature has proven important to our platform users, it
 will be available in Lightning. If there is any feature you require in Lightning
-to be able to switch over to it, speak up ! You can reach out to our product
-manager Amber via [email](mailto:amber@openfn.org) or even better book some time
-with her through her [calendar](https://koalendar.com/e/amber-rignell-openfn).
+to be able to switch over to it, speak up! You can reach out to our team via the 
+[OpenFn Community](https://community.openfn.org/).
 
 #### When will Lightning Beta be ready?
 
-Lightning is currently in private Beta. You can register for an account on
-[app.openfn.org](https://app.openfn.org/).
+Lightning is currently in Beta. You can register for an account on
+[app.openfn.org](https://app.openfn.org/). Lightning will be released
+in Q4 2023.


### PR DESCRIPTION
Remove mention of Amber and update timeline for Lightning release (Q4 2023)