### PR TITLE
CLI Challenges amended with new COVID API and markdown formatting

### DIFF
--- a/docs/build-for-developers/cli-challenges.md
+++ b/docs/build-for-developers/cli-challenges.md
@@ -4,7 +4,7 @@ sidebar_label: CLI Challenges
 slug: /cli-challenges
 ---
 
-#### Solve real-world problems and showcase your command-line skills by participating in our CLI challenges.
+#### Solve real-world problems and showcase your command-line skills by participating in our CLI challenges
 
 :::tip Important Notes
 
@@ -16,7 +16,7 @@ slug: /cli-challenges
   <details>
   <summary>Expand to see bug report template</summary>
 
-  ```
+  ```markdown
 
   Subject: Bug Report - [Brief Description]
 
@@ -93,9 +93,15 @@ Fetch and print the details of the first user from the JSONPlaceholder API.
 
 **Requirements:**
 
-1. Utilize the
+1. Install the latest version of http adaptor.
+
+```bash
+openfn repo install @openfn/language-http
+```
+
+2. Utilize the
    [JSONPlaceholder API](https://jsonplaceholder.typicode.com/users).
-2. Create a file named `getUsers.js` to contain the script.
+3. Create a file named `getUsers.js` to contain the script.
 
 **Tasks:**
 
@@ -119,19 +125,19 @@ Fetch and print the details of the first user from the JSONPlaceholder API.
 
 **Overview:**
 
-Fetch and present COVID-19 metadata using the
-[disease.sh API](https://disease.sh/).
+Fetch and present COVID-19 metadata using
+[The Atlantic's COVID Tracking Project API](https://covidtracking.com/data/api).
 
 **Objective:**
 
-Write a job that retrieves comprehensive COVID-19 data from the API and group it
-by region.
+Write a job that retrieves COVID-19 data from the API and calculate some
+aggregate values across a length of time of your chosing.
 
 **Requirements:**
 
-1.  Install the latest version of http adaptor.
+1. Install the latest version of http adaptor.
 
-```
+```bash
 openfn repo install @openfn/language-http
 ```
 


### PR DESCRIPTION
This changeset includes:

- Amended the COVID challenge to use a different API as the original appears to no longer be working.
- Markdown formatting likes for code blocks to include the language.
- Moved up the installation of http adaptor to the first challenge that expects a user to use it.

<img width="1038" alt="image" src="https://github.com/OpenFn/docs/assets/1723339/479b4549-a9e1-463c-bdf5-24fea1328941">
