### PR TITLE
Update Covid-19 API Url 

### DIFF
--- a/docs/build-for-developers/cli-challenges.md
+++ b/docs/build-for-developers/cli-challenges.md
@@ -4,7 +4,7 @@ sidebar_label: CLI challenges
 slug: /cli-challenges
 ---
 
-#### Solve real-world problems and showcase your command-line skills by participating in our CLI challenges.
+#### Solve real-world problems and showcase your command-line skills by participating in our CLI challenges
 
 :::tip Important Notes
 
@@ -16,7 +16,7 @@ slug: /cli-challenges
   <details>
   <summary>Expand to see bug report template</summary>
 
-  ```
+  ```markdown
 
   Subject: Bug Report - [Brief Description]
 
@@ -93,9 +93,15 @@ Fetch and print the details of the first user from the JSONPlaceholder API.
 
 **Requirements:**
 
-1. Utilize the
+1. Install the latest version of http adaptor.
+
+```bash
+openfn repo install @openfn/language-http
+```
+
+2. Utilize the
    [JSONPlaceholder API](https://jsonplaceholder.typicode.com/users).
-2. Create a file named `getUsers.js` to contain the script.
+3. Create a file named `getUsers.js` to contain the script.
 
 **Tasks:**
 
@@ -119,19 +125,19 @@ Fetch and print the details of the first user from the JSONPlaceholder API.
 
 **Overview:**
 
-Fetch and present COVID-19 metadata using the
-[disease.sh API](https://disease.sh/).
+Fetch and present COVID-19 metadata using
+[The Atlantic's COVID Tracking Project API](https://covidtracking.com/data/api).
 
 **Objective:**
 
-Write a job that retrieves comprehensive COVID-19 data from the API and group it
-by region.
+Write a job that retrieves COVID-19 data from the API and calculate some
+aggregate values across a length of time of your chosing.
 
 **Requirements:**
 
-1.  Install the latest version of http adaptor.
+1. Install the latest version of http adaptor.
 
-```
+```bash
 openfn repo install @openfn/language-http
 ```
 

--- a/docs/build-for-developers/cli-challenges.md
+++ b/docs/build-for-developers/cli-challenges.md
@@ -17,26 +17,24 @@ slug: /cli-challenges
   <summary>Expand to see bug report template</summary>
 
   ```markdown
-
   Subject: Bug Report - [Brief Description]
 
-  **Description:**
-  [Concise description of the bug.]
+  **Description:** [Concise description of the bug.]
 
   **Steps to Reproduce:**
+
   1.
   2.
   3.
 
   **Environment:**
+
   - OS: [e.g., Windows 10]
   - CLI: [e.g., v0.4.11]
   - Node: [e.g., v 18.17.1]
   - NPM: [e.g., 8.19.2]
 
-  **Attachments:**
-  [Screenshots, error messages, or relevant files.]
-
+  **Attachments:** [Screenshots, error messages, or relevant files.]
   ```
 
   </details>
@@ -144,8 +142,8 @@ openfn repo install @openfn/language-http
 **Tasks:**
 
 1. Write an OpenFn operation to pull COVID-19 metadata from the
-   [disease.sh API](https://disease.sh/).
-   - Utilize `https://disease.sh/v3/covid-19/` as your **baseUrl** in
+   [The Atlantic's COVID Tracking Project API](https://covidtracking.com/data/api).
+   - Utilize `https://api.covidtracking.com` as your **baseUrl** in
      `state.configuration`.
 2. Run the job using the OpenFn CLI with the command
    `openfn your_operation_file.js -a http -o tmp/output.json`.

--- a/versioned_docs/version-legacy/cli.md
+++ b/versioned_docs/version-legacy/cli.md
@@ -39,7 +39,8 @@ to use and understand OpenFn.
 :::caution Looking for a way to execute jobs from OpenFn v1 locally? Use Core!
 
 If you're looking for a way to execute jobs running on the OpenFn v1 platform,
-please see the documentation for **[@openfn/core](https://github.com/OpenFn/core)** and
+please see the documentation for
+**[@openfn/core](https://github.com/OpenFn/core)** and
 [Devtools](https://github.com/OpenFn/devtools).
 
 :::
@@ -812,9 +813,9 @@ between systems in a structured and automated way.
 _For example, if you have two jobs in your workflow (GET users from system A &
 POST users to system B), you can set up your workflow to run all jobs in
 sequence from start to finish. This imitates the
-[flow trigger patterns](./build/triggers.md#flow-triggers)
-on the OpenFn platform where a second job should run after the first one
-succeeds, respectively, using the data returned from the first job. “_
+[flow trigger patterns](./build/triggers.md#flow-triggers) on the OpenFn
+platform where a second job should run after the first one succeeds,
+respectively, using the data returned from the first job. “_
 
 :::info tl;dr
 

--- a/versioned_docs/version-legacy/cli.md
+++ b/versioned_docs/version-legacy/cli.md
@@ -217,17 +217,17 @@ openfn test --log debug
 
       <summary>View expected output</summary>
 
-      ```bash
-        [CLI] ⚠ WARNING: No adaptor provided!
-        [CLI] ⚠ This job will probably fail. Pass an adaptor with the -a flag, eg:
-                  openfn job.js -a common
-        [CLI] ✔ Compiled from helo.js
-        [R/T] ♦ Starting job job-1
-        [JOB] ℹ Hello World!
-        [R/T] ✔ Completed job job-1 in 1ms
-        [CLI] ✔ State written to tmp/output.json
-        [CLI] ✔ Finished in 17ms ✨
-      ```
+    ```bash
+      [CLI] ⚠ WARNING: No adaptor provided!
+      [CLI] ⚠ This job will probably fail. Pass an adaptor with the -a flag, eg:
+                openfn job.js -a common
+      [CLI] ✔ Compiled from helo.js
+      [R/T] ♦ Starting job job-1
+      [JOB] ℹ Hello World!
+      [R/T] ✔ Completed job job-1 in 1ms
+      [CLI] ✔ State written to tmp/output.json
+      [CLI] ✔ Finished in 17ms ✨
+    ```
 
     </details>
 
@@ -511,12 +511,13 @@ of how to set up `state.configuration` for `language-http`.
 
 #### 🏆 Challenge: Fetch Covid-19 metadata
 
-1. Using the [disease.sh API](https://disease.sh/), write an operation that
-   returns all covid-19 metadata.
+1. Using the
+   [The Atlantic's COVID Tracking Project API](https://covidtracking.com/data/api).,
+   write an operation that returns all covid-19 metadata.
 
 :::tip
 
-`https://disease.sh/v3/covid-19/` as your **baseUrl** in `state.configuration`
+`https://api.covidtracking.com` as your **baseUrl** in `state.configuration`
 
 :::
 


### PR DESCRIPTION
### Description
CLI Challenges amended with new COVID API and markdown formatting #400

### Details
- Amended the COVID challenge to use a different API as the original appears to no longer be working.
- Markdown formatting likes for code blocks to include the language.
- Moved up the installation of http adaptor to the first challenge that expects a user to use it.

### Additional Context 
This was also spotted by @hunterachieng See issue #393 for more details. This PR is @bentleycook contribution, see #400 

### Remaining Task
- [x] Fix broken Urls, [See the following failed checks](https://github.com/OpenFn/docs/pull/400/checks)
- [x] Update platform CLI challenge https://docs.openfn.org/documentation/cli#-challenge-fetch-covid-19-metadata