### PR TITLE
Lazy State Docs

### DIFF
--- a/docs/jobs/job-writing-guide.md
+++ b/docs/jobs/job-writing-guide.md
@@ -297,17 +297,12 @@ to send it somewhere else.
 
 Can you see the problem?
 
-It happens all the time.
+The value of `state.data` in the post call will resolve to `undefined`.
 
-Because of the way JavaScript works, `state.data` will be evaluated before the
+Because of the way JavaScript works, `state.data` will be evaluated _before_ the
 `get()` request has finished. So the post will always receive a value of
-`undefined`.
+`undefined`, and the post will not behave as expected.
 
-<!--
-Ok wise guy, how are we gonna explain this?
-It's something to do with factories, and closures, and synchronous execution.
-What's the simplest explanation though?
--->
 <details>
 <summary>Okay, how <i>does</i> JavaScript work?</summary>
 JavaScript, like most languages, will evaluate synchronously, executing code line of code one at a time.
@@ -336,7 +331,7 @@ basically uninitialised.
 
 </details>
 
-What we actually need to do is defer the evaluation of `state.data` until the
+What we actually need to do is _defer_ the evaluation of `state.data` until the
 `post` operation actually runs. In other words, we work out the value of
 `state.data` at last possible moment.
 
@@ -345,54 +340,85 @@ a bit verbose (there are many examples in this guide), and some operations
 support JSON path strings. The preferred way in modern OpenFn is to use an
 inline-function:
 
+<!-- prettier-ignore -->
 ```js
 get('/some-data');
-post('/some-other-data', state => state.data);
+post('/some-other-data', (state) => state.data);
 ```
 
-This passes a function into the `post` operator. When the `post()` call actually
-executes, the first thing it'll do is resolve any function into arguments into
-values. It does this by calling the function passing in the latest state, and
-using the return as the value.
+This passes a _function_ into the `post` operator, instead of a value.
+
+When the `post()` call actually executes, the first thing it'll do is resolve
+any function into arguments into values. It does this by calling the function
+passing in the latest state, and using the return as the value.
 
 These lazy functions are incredibly powerful. Using them effectively is the key
 to writing good OpenFn jobs.
 
 ## The Lazy State Operator
 
-The Lazy State Operator makes it easier to read from state.
-
 :::tip Experimental Feature
 
-The Lazy State operator is new to OpenFn since April 2024. It is still
+The Lazy State operator is new to OpenFn as of April 2024. It is still
 considered an experimental feature. But it works great, and we encourage you to
 use it!
 
 If you've got any feedback, issues or suggestions around the Lazy State
-Operator, we'd love to hear from you on community! Or you can raise an issue on
-GitHub. :::
+Operator, we'd love to hear from you on
+[Community](https://community.openfn.org)! Or you can raise an issue on
+[GitHub](https://github.com/openfn/kit/issues).
 
-Instead of writing `state.data` to access something on state, you can use the
-State Operator, `$`, like this:
+:::
+
+The Lazy State Operator is a shorthand syntax that makes it easier to read state
+when passing data into an operation.
+
+Instead of writing `state.data` to access something on state, you can use `$`,
+like this:
 
 ```js
 get($.data.url);
 ```
 
-If you use the Lazy State Operator, you don't need to think about lazy
-references, arrow functions or JSON paths. Just read from `$` like your state
-object and the OpenFn runtime will resolve the value correctly at run-time.
+The `$` ensures that the value passed to the operation will be resolved at the
+correct time. Think of it like passing a path to some part of state, rather than
+passing the value of that path.
+
+What's nice about this is that you can basically ignore the previous chapter
+entirely and not think too much about state evaluation. Just read from `$` like
+your state object and the OpenFn runtime will resolve the value correctly at
+run-time.
 
 The `$` symbol is really just syntactic sugar for `(state) => state` (in most
 cases, we just do a string replace when compiling your code). These two
 statements behave in exactly the same way:
 
+<!-- prettier-ignore -->
 ```js
 get($.data.url);
-get(state => state.data.url);
+get((state) => state.data.url);
 ```
 
-You can use the Lazy State operator when passing an argument to any operation:
+We call it "lazy state" because the reference will be resolved by the runtime
+engine immediately before its used. This bypasses a lot of the aysnchronicity
+problems of Javascript which are disccused in
+[Reading State Lazily](#reading-state-lazily)
+
+:::tip $ Only works within Operations
+
+`$` only works when used inside an expression that's passed to an operation. In
+other words, you can only use it when you could write `(state) => state` instead
+(like the example above).
+
+:::
+
+### Usage Examples
+
+The following short code snippets show some examples of how the Lazy State
+Operator can be used. Each example can be re-written without `$`, but with it
+the syntax is shorter, more readable and more expressive.
+
+Basic usage is simply to pass state into an operation:
 
 ```js
 upsert('patient', $.data.patients[0]);
@@ -422,7 +448,15 @@ create({
 });
 ```
 
-And you can use it when mapping datastructures:
+Or mathematics:
+
+```js
+create({
+  profit: $.report.revenue - $.report.expenses,
+});
+```
+
+You can use it when mapping datastructures:
 
 ```js
 create('user', {
@@ -430,33 +464,40 @@ create('user', {
 });
 ```
 
-:::warning $ is not state
+And you can use it in nested operations like, with `each()`:
 
-The `$` operator is not an alias for `state`.
+<!-- prettier-ignore -->
+```js
+each($.data.patients,
+  post(`patients/${$.data.patient.id}`, $.data.patient)
+);
+```
+
+### $ is not state
+
+The `$` operator is **not** an alias for `state`.
 
 It cannot be used in place of the `state` variable. It cannot be assigned to, or
 be on the left hand side of an assignment, and can only be used inside an
 arugment to a function
 
-Tihs also means that Lazy State Operator can only be used to READ from state. It
+This also means that Lazy State Operator can only be used to READ from state. It
 cannot be used to assign to state directly.
 
 These examples are all errors:
 
-```
-const url = $.data.url
-get(url)
+```js
+❌ const url = $.data.url;
+get(url);
 
-get(() => $.data.url)
+❌ get(() => $.data.url);
 
-$.data.x = fn();
+❌ $.data.x = fn();
 
-fn((state) => {
+❌ fn(state => {
   $.data.x = 10;
-})
+});
 ```
-
-:::
 
 <details>
 <summary>Compliation rules for advanced users</summary>

--- a/docs/jobs/job-writing-guide.md
+++ b/docs/jobs/job-writing-guide.md
@@ -358,18 +358,19 @@ using the return as the value.
 These lazy functions are incredibly powerful. Using them effectively is the key
 to writing good OpenFn jobs.
 
-## The State Operator
+## The Lazy State Operator
 
-The State Operator makes lazy state reading (as outlined above) easier.
+The Lazy State Operator makes it easier to read from state.
 
 :::tip Experimental Feature
 
-The State operator is new to OpenFn since April 2024. It is still considered an
-experimental feature. But it works great, and we encourage you to use it!
+The Lazy State operator is new to OpenFn since April 2024. It is still
+considered an experimental feature. But it works great, and we encourage you to
+use it!
 
-If you've got any feedback, issues or suggestions around the State Operator,
-we'd love to hear from you on community! Or you can raise an issue on GitHub.
-:::
+If you've got any feedback, issues or suggestions around the Lazy State
+Operator, we'd love to hear from you on community! Or you can raise an issue on
+GitHub. :::
 
 Instead of writing `state.data` to access something on state, you can use the
 State Operator, `$`, like this:
@@ -378,9 +379,9 @@ State Operator, `$`, like this:
 get($.data.url);
 ```
 
-If you use the State Operator, you don't need to think about lazy references,
-arrow functions or JSON paths. Just read from `$` like your state object and the
-OpenFn runtime will resolve the value correctly at run-time.
+If you use the Lazy State Operator, you don't need to think about lazy
+references, arrow functions or JSON paths. Just read from `$` like your state
+object and the OpenFn runtime will resolve the value correctly at run-time.
 
 The `$` symbol is really just syntactic sugar for `(state) => state` (in most
 cases, we just do a string replace when compiling your code). These two
@@ -391,7 +392,7 @@ get($.data.url);
 get(state => state.data.url);
 ```
 
-You can use the State operator when passing an argument to any operation:
+You can use the Lazy State operator when passing an argument to any operation:
 
 ```js
 upsert('patient', $.data.patients[0]);
@@ -429,17 +430,38 @@ create('user', {
 });
 ```
 
-:::warning $ is read only
+:::warning $ is not state
 
-The State Operator can only be used to READ from state. It cannot be used to
-assign to state directly.
+The `$` operator is not an alias for `state`.
+
+It cannot be used in place of the `state` variable. It cannot be assigned to, or
+be on the left hand side of an assignment, and can only be used inside an
+arugment to a function
+
+Tihs also means that Lazy State Operator can only be used to READ from state. It
+cannot be used to assign to state directly.
+
+These examples are all errors:
+
+```
+const url = $.data.url
+get(url)
+
+get(() => $.data.url)
+
+$.data.x = fn();
+
+fn((state) => {
+  $.data.x = 10;
+})
+```
 
 :::
 
 <details>
 <summary>Compliation rules for advanced users</summary>
 
-How does the State Operator work? The "magic" is in the compiler.
+How does the Lazy State Operator work? The "magic" is in the compiler.
 
 Simply put, whenever the compiler sees `$` in your code, it replaces it with
 `(state) => state`. Like this:


### PR DESCRIPTION
This PR adds docs for the Lazy State operator.

I'm just going to call it the State Operator in public.

I am not ready to re-write all our docs examples using `$.data`, or remove the complicated "lazy state loading" section. I think it's appropriate for now to document this as an experimental new feature.

If it sticks (and I am sure it will), then we can overhaul the docs in a couple of months time to put the state operator front and center. @aleksa-krolls  asked for a single way to read from state and I think this is it.

This should be merged after the latest fix is released.