### PR TITLE
clarify v1 archive steps

### DIFF
--- a/docs/deploy/options.md
+++ b/docs/deploy/options.md
@@ -104,9 +104,9 @@ proven, and you're ready to scale it up.
 ## Technical Guidelines
 
 For detailed deployment documentation instructions, head to the Lightning
-[developer docs page](https://openfn.github.io/Lightning/readme.html), paying
+[developer docs page](https://openfn.github.io/lightning/readme.html), paying
 special attention to several sections:
 
-1. [Getting Started](https://openfn.github.io/Lightning/readme.html#getting-started)
-2. [Deployment Considerations](https://openfn.github.io/Lightning/deployment.html)
-3. [Benchmarking](https://openfn.github.io/Lightning/benchmarking.html)
+1. [Getting Started](https://openfn.github.io/lightning/readme.html#getting-started)
+2. [Deployment Considerations](https://openfn.github.io/lightning/deployment.html)
+3. [Benchmarking](https://openfn.github.io/lightning/benchmarking.html)

--- a/docs/migration/automated-migration.md
+++ b/docs/migration/automated-migration.md
@@ -4,24 +4,27 @@ sidebar_label: Automate Migration
 ---
 
 You can use our `export and deploy` functionality to self-migrate your existing
-OpenFn project configuration from v1 to v2. This guide walks you through the
-steps.
+OpenFn project configuration from v1 to v2, or between two different v2
+instances. This guide walks you through the steps.
 
-### Automating migration of your OpenFn v1 Project to v2
+### v1-to-v2: Automating migration of your OpenFn v1 Project to v2
 
 You can export your existing project configuration containing the jobs and
 triggers from v1, then use the OpenFn
 [CLI](https://github.com/OpenFn/kit/tree/main/packages/cli) tool to deploy it to
 your v2 project space. To start, make sure you have the latest version of the
-CLI installed. To learn more about the project configuration as code, head over
-to our [Portability](../deploy/portability.md) page.
+CLI installed ([see CLI basic docs](../docs/build-for-developers/cli-intro.md)).
+To learn more about the project configuration as code, head over to our
+[Portability](../deploy/portability.md) page.
 
 In order to be able to deploy the project, you need to have at least `admin`
-access to the v2 project you're deploying to. In addition, make sure you have
-the right [pricing plan](https://www.openfn.org/pricing) to accomodate the 
-number of workflows, runs, and features you desire for your v2 project. 
+access to the v2 project you're deploying to. In addition, if you're migrating
+to a project on the OpenFn-hosted platform (on
+[app.openfn.org](https://app.openfn.org)) make sure you have the right
+[pricing plan](https://www.openfn.org/pricing) to accomodate the number of
+workflows, runs, and features you desire for your v2 project.
 
-### Exporting Your v1 Project
+#### Exporting Your v1 Project
 
 1. Navigate to `Project Settings` on your https://v1.openfn.org/ project.
 2. Click `Export Config` under the Project Configuration section and choose
@@ -30,7 +33,7 @@ number of workflows, runs, and features you desire for your v2 project.
 3. Download the exported `project.yaml` file and save it in a folder on your
    computer.
 
-### Setup and Deployment to v2
+#### Setup and Deployment to v2
 
 4. In a code editor, create a new `config.json` file with the following content:
 
@@ -106,5 +109,26 @@ When prompted, confirm you want to deploy by typing `y` ("yes").
 Ask on [Community](https://community.openfn.org) if you run into issues or
 questions. For an overview of all the recommended v1-to-v2 migration steps,
 check out the [Migration Steps docs](../migration/migration-steps.md).
+
+:::
+
+### v2-to-v2: Automating project migration from one OpenFn v2 instance to another
+
+If you want to migrate a project from one instance of OpenFn v2 (e.g., the
+cloud-hosted [app.openfn.org](https://app.openfn.org)) to another (e.g., your
+local deployment of the v2), you can also leverage the OpenFn
+[CLI](https://github.com/OpenFn/kit/tree/main/packages/cli) tool. To start, make
+sure you have the latest version of the CLI installed
+([see CLI basic docs](../docs/build-for-developers/cli-intro.md)).
+
+::: info v2-to-v2 Migration Guide coming soon! 
+
+A detailed guide on how to
+migrate projects between two instances of OpenFn v2
+([lightning](https://github.com/OpenFn/lightning)) is coming soon.
+
+To learn more about OpenFn deployment, be sure to check out our
+[planning guide](https://docs.openfn.org/documentation/deploy/options) and
+[technical guidelines](https://docs.openfn.org/documentation/deploy/options#technical-guidelines).
 
 :::

--- a/docs/migration/migration-steps.md
+++ b/docs/migration/migration-steps.md
@@ -86,8 +86,7 @@ decisions. For customized migration support, ask your questions on our
 18. Turn "off" your Jobs on v1 and delete the GitHub connection in your v1
     Project Settings to disable version control.
 19. You have the option to export some of your v1 data: `Messages` and `Run History` for
-    reference or archival. To do this, visit the `Downloads` page. Your most recent downloadable `receipts archives` and `runs archives` are at the bottom of the export list. You can also get
-    in touch with us at [support@openfn.org](mailto://support@openfn.org) for help.
+    reference or archival. To do this, visit the `Downloads` page in your v1 project. Your most recent downloadable `receipts archives` and `runs archives` are at the bottom of the export list. You can generate a new export by navigating to the `Inbox` or `Activity History` page, filtering your view to query the desired data to export, and then select the cloud ☁ icon to `Export to csv`. 
 20. Finally, when ready, request to delete your project on v1. To do this, go to
     your v1 `Project Settings` and select the `Delete Project` button.
 

--- a/docs/migration/migration-steps.md
+++ b/docs/migration/migration-steps.md
@@ -85,9 +85,9 @@ decisions. For customized migration support, ask your questions on our
     shut down your v1 project.
 18. Turn "off" your Jobs on v1 and delete the GitHub connection in your v1
     Project Settings to disable version control.
-19. If you want to export your v1 data (incl. `Messages` and `Run History`) for
-    reference or archival, visit the `Exports` page in Project Settings or get
-    in touch with us at [support@openfn.org](mailto://support@openfn.org).
+19. You have the option to export some of your v1 data: `Messages` and `Run History` for
+    reference or archival. To do this, visit the `Downloads` page. Your most recent downloadable `receipts archives` and `runs archives` are at the bottom of the export list. You can also get
+    in touch with us at [support@openfn.org](mailto://support@openfn.org) for help.
 20. Finally, when ready, request to delete your project on v1. To do this, go to
     your v1 `Project Settings` and select the `Delete Project` button.
 

--- a/versioned_docs/version-legacy/deploy/options.md
+++ b/versioned_docs/version-legacy/deploy/options.md
@@ -104,9 +104,9 @@ proven, and you're ready to scale it up.
 ## Technical Guidelines
 
 For detailed deployment documentation instructions, head to the Lightning
-[developer docs page](https://openfn.github.io/Lightning/readme.html), paying
+[developer docs page](https://openfn.github.io/lightning/readme.html), paying
 special attention to several sections:
 
-1. [Getting Started](https://openfn.github.io/Lightning/readme.html#getting-started)
-2. [Deployment Considerations](https://openfn.github.io/Lightning/deployment.html)
-3. [Benchmarking](https://openfn.github.io/Lightning/benchmarking.html)
+1. [Getting Started](https://openfn.github.io/lightning/readme.html#getting-started)
+2. [Deployment Considerations](https://openfn.github.io/lightning/deployment.html)
+3. [Benchmarking](https://openfn.github.io/lightning/benchmarking.html)


### PR DESCRIPTION
Clarify v1 archive steps, mention v2-to-v2 project migration is possible, and fix broken links on deployment page