### PR TITLE
allow generate adaptors to run from local adaptors monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ yarn install
 
 #### Windows
 
-Install [nvm-windows](https://github.com/coreybutler/nvm-windows). Make sure your `node` version matches the one specified in `.tool-versions`. 
+Install [nvm-windows](https://github.com/coreybutler/nvm-windows). Make sure
+your `node` version matches the one specified in `.tool-versions`.
 
 ### Starting your docs site server
 
@@ -68,6 +69,25 @@ yarn generate-library
 
 This command pulls public job data from OpenFn.org to create a local "job
 library".
+
+### Building the adaptors docs from the monorepo
+
+```
+yarn start:dev
+```
+
+Or, if the server is running:
+
+```
+yarn generate-adaptors -m
+```
+
+Ensure that the OPENFN_ADAPTORS_REPO env var is set and points to the local
+monorepo.
+
+See
+(github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes)[https://github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes]
+for more details
 
 ### Build and serve for full-featured testing
 

--- a/generate-adaptors/index.js
+++ b/generate-adaptors/index.js
@@ -69,6 +69,8 @@ async function loadAdaptorsDocsFromMonorepo() {
   console.log('Loading adaptors docs from adaptors monorepo at ', baseDir);
 
   try {
+    // Read from tmp not from docs, because otherwise the adaptor
+    // build script won't work properly
     const raw = fs.readFileSync(path.resolve(baseDir, 'tmp/docs.json'));
     return JSON.parse(raw);
   } catch (e) {
@@ -245,47 +247,38 @@ module.exports = function (context, { apiUrl }) {
               console.warn('WARNING: No name for ', a);
               return;
             }
-            try {
-              const docsBody = generateJsDoc(a);
-              const readmeBody = generateReadme(a);
-              const changelogBody = generateChangelog(a);
 
-              const configurationSchemaBody = generateConfigurationSchema(a);
+            const docsBody = generateJsDoc(a);
+            const readmeBody = generateReadme(a);
+            const changelogBody = generateChangelog(a);
 
-              pushToPaths(a.name);
+            const configurationSchemaBody = generateConfigurationSchema(a);
 
-              fs.writeFileSync(
-                `./adaptors/packages/${a.name}-docs.md`,
-                docsBody
-              );
-              fs.writeFileSync(
-                `./adaptors/packages/${a.name}-readme.md`,
-                readmeBody
-              );
-              fs.writeFileSync(
-                `./adaptors/packages/${a.name}-changelog.md`,
-                changelogBody
-              );
-              fs.writeFileSync(
-                `./adaptors/packages/${a.name}-configuration-schema.md`,
-                configurationSchemaBody
-              );
-              console.log('Done ✓');
+            pushToPaths(a.name);
 
-              console.log('Creating sidebar paths...');
+            fs.writeFileSync(`./adaptors/packages/${a.name}-docs.md`, docsBody);
+            fs.writeFileSync(
+              `./adaptors/packages/${a.name}-readme.md`,
+              readmeBody
+            );
+            fs.writeFileSync(
+              `./adaptors/packages/${a.name}-changelog.md`,
+              changelogBody
+            );
+            fs.writeFileSync(
+              `./adaptors/packages/${a.name}-configuration-schema.md`,
+              configurationSchemaBody
+            );
 
-              fs.writeFileSync(
-                './adaptors/packages/publicPaths.json',
-                JSON.stringify(filePaths, null, 2)
-              );
-            } catch (e) {
-              console.error('Error generating for ', a.name);
-              console.log(e);
-              throw e;
-            }
+            fs.writeFileSync(
+              './adaptors/packages/publicPaths.json',
+              JSON.stringify(filePaths, null, 2)
+            );
+
+            console.log(`Done ${a.name} ✓`);
           });
 
-          console.log('Done ✓');
+          console.log('Done all adaptors ✓');
         });
     },
   };

--- a/generate-adaptors/index.js
+++ b/generate-adaptors/index.js
@@ -241,6 +241,10 @@ module.exports = function (context, { apiUrl }) {
           console.log('Generating adaptors docs via JSDoc...');
 
           adaptors.map(a => {
+            if (!a.name) {
+              console.warn('WARNING: No name for ', a);
+              return;
+            }
             try {
               const docsBody = generateJsDoc(a);
               const readmeBody = generateReadme(a);

--- a/generate-adaptors/index.js
+++ b/generate-adaptors/index.js
@@ -246,7 +246,7 @@ module.exports = function (context, { apiUrl }) {
               JSON.stringify(versions, null, 2)
             );
           } else {
-            console.warning('Skipping version list as loading from monorepo');
+            console.warn('Skipping version list as loading from monorepo');
           }
 
           const adaptors = await (useMonorepo

--- a/generate-adaptors/index.js
+++ b/generate-adaptors/index.js
@@ -234,8 +234,7 @@ module.exports = function (context, { apiUrl }) {
             useMonorepo = true;
           }
 
-          // TODO if using the monorepo, what do we do about versions?
-          if (useMonorepo) {
+          if (!useMonorepo) {
             console.log('Getting version list...');
             await listVersions();
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "generate-library": "docusaurus generate-library",
     "generate-adaptors": "docusaurus generate-adaptors",
     "start": "docusaurus generate-adaptors && docusaurus start",
+    "start:dev": "docusaurus generate-adaptors -m && docusaurus start",
     "start-offline": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",


### PR DESCRIPTION
There's not really any way to preview changes made in the adaptors monorepo against the docsite. So you don't really know if its rendering right until you deploy.

To preview changes locally right now, you have to make a bunch of hacks in the code in the docsite AND the adaptors monorepo.

This PR makes it easy for the docs site to use the mono repo


## Usage

Set the `OPENFN_ADAPTORS_REPO` env var to point to the monorepo

Start the server with `yarn start:dev` to build from the monorepo on first load

If the server is running. run `yarn generate-adaptors -m` to rebuild from the adaptors list.

Note that the versions list is skipped if loading from the monorepo

## Docs

I've made a little guide in the adaptors repo https://github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes


## TODO

* [x] Add some docs here
* [x] Should we use a flag as well as the env var? I think the env var is too squishy. But the solution has to work with build and docgen, so it can't just be a docgen CLI thing