### PR TITLE
Fix links in triggers page

### DIFF
--- a/docs/build/triggers.md
+++ b/docs/build/triggers.md
@@ -2,20 +2,19 @@
 title: Triggers
 ---
 
-Triggers allow you to start the executiong of workflows automatically. They come
-in two types: "cron" triggers and "webhook event" triggers.
+Triggers allow you to start the execution of workflows automatically. They come
+in two types: Cron triggers and Webhook Event triggers.
 
-## Trigger types
-
-### Webhook Event Triggers
+## Webhook Event Triggers
 
 **Webhook Event Triggers** listen for inbound HTTP requests (messages from other
 systems), and enable real-time, event-based automation.
 
-- These triggers are fired by "pushing" data to OpenFn (i.e., by sending an HTTP
-  “POST” request to your trigger’s designated URL).
-- The triggering HTTP request might be sent via a webhook in an external app,
-  another OpenFn workflow, or manually (i.e., via cURL request).
+These triggers are fired by "pushing" data to OpenFn (i.e., by sending an HTTP
+“POST” request to your trigger’s designated URL).
+
+The triggering HTTP request might be sent via a webhook in an external app,
+another OpenFn workflow, or manually (i.e., via cURL request).
 
 ![Webhook Trigger](/img/webhook_trigger.png)
 
@@ -26,23 +25,15 @@ Trigger by adding authentication, head over to our
 Learn how a workflow's initial `state` gets built from a webhook trigger
 [here](../jobs/state#webhook-triggered-runs).
 
-### Cron Triggers (formerly timers)
+## Cron Triggers (formerly timers)
 
 **Cron Triggers** run Workflows based on a cron schedule, and are good for
 repetitive tasks that are time-based (e.g., every day at 8am, sync financial
 data).
 
-- These Triggers enable users to “pull” data from connected systems.
-- You can pick a standard schedule (e.g., every day, or every month), or define
-  a custom schedule using cron expressions.
-
-These Triggers enable Workflows to be run as frequently as once every minutes,
-or as infrequently as you desire and can be scheuled on very specific dates or
-times.
-
-Each time a timed job succeeds, its `final_state` will be saved and used as the
-`initial_state` for its next run. See "Managing state" and "Keeping a cursor"
-below for implementation help.
+These Triggers enable users to “pull” data from connected systems. You can pick
+a standard schedule (e.g., every day, or every month), or define a custom
+schedule using cron expressions.
 
 ![Cron Trigger](/img/cron_trigger.png)
 
@@ -54,10 +45,25 @@ the OpenFn interface or
 
 :::
 
+Cron Triggers enable Workflows to be run as frequently as once every minutes, or
+as infrequently as you desire and can be scheduled on very specific dates or
+times.
+
+Each time a timed job succeeds, its `final_state` will be saved and used as the
+input state for its next run.
+[Webhook Security](../manage-projects/webhook-auth.md) page.
+
+Learn how a workflow's initial `state` gets built from a cron trigger
+[here](../jobs/state#cron-triggered-runs).
+
+You can use a Cursor to help build input state when the workflow is triggered:
+see the [Job Writing Guide](../jobs/job-writing-guide#using-cursors) for more
+details.
+
 Learn how `state` gets built from a cron trigger
 [here](../jobs/state#cron-triggered-runs).
 
-#### Managing the size of `state` for Cron Workflows
+### Managing the size of `state` for Cron Workflows
 
 Since state is passed between each run of a cron Workflow, if your Workflow Step
 adds something new to state each time it runs, it may quickly become too large
@@ -72,7 +78,7 @@ succeed but its `final_state` will not be saved and the next time that job runs
 it will inherit the previous, un-updated final state. (I.e., the last state that
 was < 50,000 bytes.)
 
-#### A quick fix for final state bloat
+### A quick fix for final state bloat
 
 Most often, final state bloat is due to improper handling of `state.references`
 or `state.data`. This can be fixed by adding the following lines _either_ to the


### PR DESCRIPTION
Here's what [https://docs.openfn.org/documentation/build/triggers](https://docs.openfn.org/documentation/build/triggers) looks like right now:

![image](https://github.com/OpenFn/docs/assets/7052509/b0c3eff1-3b12-4938-8b58-e25de118cb31)

The "Managing State" and "Keep a cursor" sections don't link anywhere and aren't on the page.

This was pointed out by a user over in https://github.com/OpenFn/adaptors/pull/654#issuecomment-2200916417

Looking at the legacy docs it looks things have been moved around and these got left hanging.

So I've made a few changes:
* Link the cursor stuff to the job writing guide bit on cursors
* Link to some state management stuff for triggers (although to be fair I don't think it's a very useful link)
* Removed some bullet points which I didn't think were very helpful
* Used Proper Nouns instead of "quotes"  for jargon like Webhook Event, which looks a little bit less like we're making up words
* Adjusted the  page structure to be a bit more useful