### PR TITLE
Add documentation for promises

### DIFF
--- a/docs/jobs/job-writing-guide.md
+++ b/docs/jobs/job-writing-guide.md
@@ -648,7 +648,7 @@ You can read more about the `each()` operation in
 
 The `each` function will take an array and, for each item, invoke a callback
 with a scoped state. This means it takes your state object and sets the item
-under iteration to `state.data`. In order words, `state.data` inside the
+under iteration to `state.data`. In other words, `state.data` inside the
 callback is _scoped_ to each item in the array.
 
 ```js


### PR DESCRIPTION
We've just released support in the runtime to treat every operation as a Promise.

See https://github.com/OpenFn/kit/pull/722 for all the gory details.

The tl;dr on this is:

1) You can now do `fn().catch()`
2) `.then()` should remove the need for 95% of callbacks in adaptor code
3) You should start doing `each($.data, fn().then())`

This is a really big deal and needs good documentation.

The tension here  is that I want to communicate the change to users who know openfn, but to new users this promises and callbacks thing is an edge case really.

In the future, most of the existing Callbacks section of the docs will be removed, and we'll just have this Promises stuff and maybe a section explaining `fn()` (because a lot of callbacks in existing job code should now migrate to using an fn block)