### PR TITLE
Updated roadmap page with links and notes

### DIFF
--- a/docs/contribute/openfn-roadmap.md
+++ b/docs/contribute/openfn-roadmap.md
@@ -1,19 +1,50 @@
 ---
-title: OpenFn Roadmap
-sidebar_label: OpenFn Roadmap
+title: Roadmap and Product Management
+sidebar_label: Roadmap
 ---
 
-:::warning Under construction
+### Introduction 
 
-This docs page is under construction. Check back later for the complete docs, or
-check out the Docs Version "Platform (v1)".
+This page details the planned roadmaps for the key products in the OpenFn
+product suite. This includes Lightning, Adaptors, and Docs. We periodically
+review the roadmap to keep it reaser up to date with the development status 
+of the features highlighted on the roadmap.
+
+
+### Our approach to product development
+At OpenFn, we have adopted [ShapeUp methodology](https://basecamp.com/shapeup) to help our 
+small product and engineeting team build products faster without compomising 
+on quality. With ShapeUp in place, we typcially commit to _projects_ that can be delivered 
+in a 4-6 weeks period with multiple releases based on QA approval within the building cycle. 
+We also proiritize feedback and feature requests from our users over features in the backlog. 
+
+### Feature Requests
+We use [Canny](https://openfn.canny.io/feature-requests) to receive, track, engage and manage 
+new feature requests from the community of users of OpenFn globally whilst giving users the 
+ability to the upvote their favoritie and mission critical feature request.
+
+#### How to request a new feature
+1. Go to [https://openfn.canny.io](https://openfn.canny.io/feature-requests)
+2. Provide a very clear, concise and descriptive title for the feature e.g. Make roadmap avaialble in French
+3. Describe this feature in detail
+4. Share this new feature request on the OpenFn community and across your professional network for upvotes
+
+:::info Tip
+
+When describing the feature, it is very helpful to help us understand the problem, proposed solution 
+(if any) and similar solutions we might glean insights from _if they exist_.
 
 :::
 
-## OpenFn Roadmap
+#### How to upvote features
+1. Go to [https://openfn.canny.io](https://openfn.canny.io/feature-requests)
+2. Scroll down or use the filter and search features to see existing feature requests  
+3. Click on the (^) beside the request to upvote. _Upvoted feature requests are prioritized for development_
+4. If you want more upvotes for this feature request, you can also share across your network 
 
-This page details the planned roadmaps for the key products in the OpenFn
-product suite. This includes OpenFn/`Lightning`, `Adaptors`, and `Docs`.
+### What are we currently working on?
+Interested in keeping up with our work? Visit our [Current Cycle GitHub board](https://github.com/orgs/OpenFn/projects/3/views/1) 
+to see what we are currently busy with and what's coming in the current cycle.
 
 ### Key for the Roadmap `Status` Values
 
@@ -80,9 +111,9 @@ workflow engine, enable automated workflows that cut across digital systems.
 | 5. Template Shared Health Record Workflows                  | Not started  | 2024                | [See OpenHIE docs](https://guides.ohie.org/arch-spec/introduction/shared-health-record); to be hosted on demo.openfn.org                      | To demonstrate how OpenFn can allow external systems to automatically save and retrieve information from the HIE (from the OpenHIE standard spec)                                                                                                                  |
 | 6. Template Aggregate Reporting Workflows                   | Not started  | 2024                | [See OpenHIE docs](https://guides.ohie.org/arch-spec/introduction/aggregate-reporting-workflows); to be hosted on demo.openfn.org             | To demonstrate how OpenFn can support aggregate data exchange of health indicators, leveraging the [ADX](https://wiki.ihe.net/index.php/Aggregate_Data_Exchange) data standard                                                                                     |
 
-### Questions? Feedback? Ideas?
+### Have questions, feedback or found a bug?
 
-Post on the OpenFn Community at
-[community.openfn.org](https://community.openfn.org), or consider contributing
-to the OpenFn software, adaptors, or documentation (learn more in the
-[Contributing section](./writing-code.md)).
+We encourage users to post their questions on the OpenFn Community at
+[community.openfn.org](https://community.openfn.org), or consider creating 
+issues for bugs via product repository. You can also independetly start contributing
+to the OpenFn software, adaptors, or documentation by getting started [here](./writing-code.md)).

--- a/docs/contribute/openfn-roadmap.md
+++ b/docs/contribute/openfn-roadmap.md
@@ -3,47 +3,60 @@ title: Roadmap and Product Management
 sidebar_label: Roadmap
 ---
 
-### Introduction 
+### Introduction
 
 This page details the planned roadmaps for the key products in the OpenFn
 product suite. This includes Lightning, Adaptors, and Docs. We periodically
-review the roadmap to keep it reaser up to date with the development status 
-of the features highlighted on the roadmap.
-
+review the roadmap to keep it reaser up to date with the development status of
+the features highlighted on the roadmap.
 
 ### Our approach to product development
-At OpenFn, we have adopted [ShapeUp methodology](https://basecamp.com/shapeup) to help our 
-small product and engineeting team build products faster without compomising 
-on quality. With ShapeUp in place, we typcially commit to _projects_ that can be delivered 
-in a 4-6 weeks period with multiple releases based on QA approval within the building cycle. 
-We also proiritize feedback and feature requests from our users over features in the backlog. 
+
+At OpenFn, we have adopted [ShapeUp methodology](https://basecamp.com/shapeup)
+to help our small product and engineeting team build products faster without
+compomising on quality. With ShapeUp in place, we typcially commit to _projects_
+that can be delivered in a 4-6 weeks period with multiple releases based on QA
+approval within the building cycle. We also proiritize feedback and feature
+requests from our users over features in the backlog.
 
 ### Feature Requests
-We use [Canny](https://openfn.canny.io/feature-requests) to receive, track, engage and manage 
-new feature requests from the community of users of OpenFn globally whilst giving users the 
-ability to the upvote their favoritie and mission critical feature request.
+
+We use [Canny](https://openfn.canny.io/feature-requests) to receive, track,
+engage and manage new feature requests from the community of users of OpenFn
+globally whilst giving users the ability to the upvote their favoritie and
+mission critical feature request.
 
 #### How to request a new feature
+
 1. Go to [https://openfn.canny.io](https://openfn.canny.io/feature-requests)
-2. Provide a very clear, concise and descriptive title for the feature e.g. Make roadmap avaialble in French
+2. Provide a very clear, concise and descriptive title for the feature e.g. Make
+   roadmap avaialble in French
 3. Describe this feature in detail
-4. Share this new feature request on the OpenFn community and across your professional network for upvotes
+4. Share this new feature request on the OpenFn community and across your
+   professional network for upvotes
 
 :::info Tip
 
-When describing the feature, it is very helpful to help us understand the problem, proposed solution 
-(if any) and similar solutions we might glean insights from _if they exist_.
+When describing the feature, it is very helpful to help us understand the
+problem, proposed solution (if any) and similar solutions we might glean
+insights from _if they exist_.
 
 :::
 
 #### How to upvote features
+
 1. Go to [https://openfn.canny.io](https://openfn.canny.io/feature-requests)
-2. Scroll down or use the filter and search features to see existing feature requests  
-3. Click on the (^) beside the request to upvote. _Upvoted feature requests are prioritized for development_
-4. If you want more upvotes for this feature request, you can also share across your network 
+2. Scroll down or use the filter and search features to see existing feature
+   requests
+3. Click on the (^) beside the request to upvote. _Upvoted feature requests are
+   prioritized for development_
+4. If you want more upvotes for this feature request, you can also share across
+   your network
 
 ### What are we currently working on?
-Interested in keeping up with our work? Visit our [Current Cycle GitHub board](https://github.com/orgs/OpenFn/projects/3/views/1) 
+
+Interested in keeping up with our work? Visit our
+[Current Cycle GitHub board](https://github.com/orgs/OpenFn/projects/3/views/1)
 to see what we are currently busy with and what's coming in the current cycle.
 
 ### Key for the Roadmap `Status` Values
@@ -60,28 +73,27 @@ OpenFn/Lightning is the fully open-source workflow automation platform at the
 core of the OpenFn Digital Public Good (learn more about the product
 [here](/documentation#openfn-v2-lightning-)).
 
-| **Feature**                                                            | **`Status`** | **Target Timeline** | **Related Links**                                                                                                                                                                   | **Description**                                                                                                                                                                                                                                        |
-| ---------------------------------------------------------------------- | ------------ | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1. Extend workflow canvas to allow branch merging                      | Delivered    | Q2 '24              | [Issue 2008](https://github.com/OpenFn/lightning/issues/2008)                                                                                                                       | Allow users to be able to skip steps and also merge two steps to one downstream step in a workflow                                                                                                                                                     |
-| 2. Implement Generic OAuth credential type                             | Delivered    | Q2 '24              | [Issue 1900](https://github.com/OpenFn/lightning/issues/1900)                                                                                                                       | Generic OAuth client and credential support for adaptors. Users can configure their own OAuth applications and credentials for OpenFn.                                                                                                                 |
-| 3. Add path params in  webhook triggers URL                            | Delivered    | Q2 '24              | [Issue 1954](https://github.com/OpenFn/lightning/issues/1954)                                                                                                                       | Support path params in wenhook URL for workflows.                                                                                                                                                                                                      |
-| 4. Automatic GitHub version control                                    | Delivered    | Q2 '24              | [Issue 970](https://github.com/OpenFn/lightning/issues/970)                                                                                                                         | Use GitHub Version Control to track and review changes to your workflow. Sync an OpenFn project and workflows to a specified GitHub repository github and allow users to be able to update OpenFn projects with GitHub versions.                       |
-| 5. Configurable data clips and history retention period                | Delivered    | Q2 '24              | [Issue 1760](https://github.com/OpenFn/lightning/issues/1760)                                                                                                                       | Allow project administrators to configure how long they want OpenFn to retain data clips and other artifacts related to a workorders in their projects                                                                                                 |
-| 6. Enable workflow snapshotting                                        | Delivered    | Q3 '24              | [Issue 1680](https://github.com/OpenFn/lightning/issues/1680)                                                                                                                       | Keep a snapshot of a snapshot based on a run or saved changes of the workflow. Allow users to be able to view snapshot and switch to the latest version of the workflow from a snapshot mode.                                                          |
-| 7. Enable configurable concurrency by workflow                         | Delivered    | Q3 '24              | [Issue 2002](https://github.com/OpenFn/lightning/issues/2022)                                                                                                                       | Allow users to control the limit of concurrent runs  per workflow in a project.                                                                                                                                                                        |
-| 8. New workflow triggers (Kafka)                                       | Delivered    | Q3 '24              | [Issue 1801](https://github.com/OpenFn/lightning/issues/1801)                                                                                                                       | Enable a new trigger type that allows users to run workflows based on messages from a Kafka cluster.                                                                                                                                                   |
-| 9. AI-enabled assitants                                                | Delivered    | Q3 '24              | [Issue 2193](https://github.com/OpenFn/lightning/issues/2193)                                                                                                                       | LLM based AI assitant that supports users with job writing, debugging and co-piloting their workflow design process.                                                                                                                                   |
-| 10. Invite new users as collaborators                                  | Delivered    | Q3 '24              | [Issue 1835](https://github.com/OpenFn/lightning/issues/1835)                                                                                                                       | Invite users who do not have OpenFn accounts to projects as collaborators.                                                                                                                                                                             |
-| 11. Allow users to create projects                                     | In dev       | Q3 '24              | [Issue 1700](https://github.com/OpenFn/Lightning/issues/1700)                                                                                                                       | All users to create new projects from their dashboard.                                                                                                                                                                                                 |
-| 12. Control log outputs                                                | Planned      | Q3 '24              | [Issue 1755](https://github.com/OpenFn/Lightning/issues/1755)                                                                                                                       | Control what is printed in run logs by specifying log levels and allow users to disable printing console.logs, for data privacy once workflows are handling production data.                                                                           |
-| 13. Allow users to export workorder history                            | Planned      | Q3 '24              | [Issue 1698](https://github.com/OpenFn/lightning/issues/1698)                                                                                                                       | Allow project users to be able to export workorder history. The workorder history contains ALL logs and data clips (Input and Output) associated with runs in a workorder.                                                                             |
-| 14. Enable manual workflow triggers                                    | Not started  | Q4 '24              | [Issue 2155](https://github.com/OpenFn/lightning/issues/2155)                                                                                                                       | Enable users to manually trigger workflow with JSON/CSV data as input data clip                                                                                                                                                                        |
-| 15. Project datastores and buffers                                     | Not started  | Q4 '24              | [Issue 2190](https://github.com/OpenFn/lightning/issues/2190)                                                                                                                       | Allow users to configure a data store or buffer that allows temporary of storage of data that can be used in a workflow.                                                                                                                               |
-| 16. Redesign workflow canvas and inspector interface                   | Not started  | Q4 '24              | [Issue 2021](https://github.com/OpenFn/lightning/issues/2021)                                                                                                                       | Make workflow design better to help user build workflow faster and easier.                                                                                                                                                                             |
-| 17. Improved workorder history page filter                             | Not started  | Q4 '24              | [Issue 1791](https://github.com/OpenFn/lightning/issues/1791)                                                                                                                       | Extend workorder history page and enable cascading filtering. This is useful for debuging, failure recovery and auditability of the workflow.                                                                                                          |
-| 18. Workflow Monitoring                                                | Not started  | Q4 '24              | [Issue 608](https://github.com/OpenFn/kit/issues/608)                                                                                                                               | Give users better visibility of what's happening on inside the worker, especially when an error occurs during run execution.                                                                                                                           |
-| 19. Expanded Audit Trail and Node Authentication (ATNA) functionality  | Not started  | Q1 '25              | [Issue 271](https://github.com/OpenFn/Lightning/issues/271)                                                                                                                         | Extend audit trail functionality to cover more aspects of ATNA, reference [OpenHIE IOL requirement IOLWF-1](https://guides.ohie.org/arch-spec/openhie-component-specifications-1/openhie-interoperability-layer-iol#openhie-iol-workflow-requirements).|
-
+| **Feature**                                                           | **`Status`** | **Target Timeline** | **Related Links**                                             | **Description**                                                                                                                                                                                                                                         |
+| --------------------------------------------------------------------- | ------------ | ------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Extend workflow canvas to allow branch merging                     | Delivered    | Q2 '24              | [Issue 2008](https://github.com/OpenFn/lightning/issues/2008) | Allow users to be able to skip steps and also merge two steps to one downstream step in a workflow                                                                                                                                                      |
+| 2. Implement Generic OAuth credential type                            | Delivered    | Q2 '24              | [Issue 1900](https://github.com/OpenFn/lightning/issues/1900) | Generic OAuth client and credential support for adaptors. Users can configure their own OAuth applications and credentials for OpenFn.                                                                                                                  |
+| 3. Add path params in webhook triggers URL                            | Delivered    | Q2 '24              | [Issue 1954](https://github.com/OpenFn/lightning/issues/1954) | Support path params in wenhook URL for workflows.                                                                                                                                                                                                       |
+| 4. Automatic GitHub version control                                   | Delivered    | Q2 '24              | [Issue 970](https://github.com/OpenFn/lightning/issues/970)   | Use GitHub Version Control to track and review changes to your workflow. Sync an OpenFn project and workflows to a specified GitHub repository github and allow users to be able to update OpenFn projects with GitHub versions.                        |
+| 5. Configurable data clips and history retention period               | Delivered    | Q2 '24              | [Issue 1760](https://github.com/OpenFn/lightning/issues/1760) | Allow project administrators to configure how long they want OpenFn to retain data clips and other artifacts related to a workorders in their projects                                                                                                  |
+| 6. Enable workflow snapshotting                                       | Delivered    | Q3 '24              | [Issue 1680](https://github.com/OpenFn/lightning/issues/1680) | Keep a snapshot of a snapshot based on a run or saved changes of the workflow. Allow users to be able to view snapshot and switch to the latest version of the workflow from a snapshot mode.                                                           |
+| 7. Enable configurable concurrency by workflow                        | Delivered    | Q3 '24              | [Issue 2002](https://github.com/OpenFn/lightning/issues/2022) | Allow users to control the limit of concurrent runs per workflow in a project.                                                                                                                                                                          |
+| 8. New workflow triggers (Kafka)                                      | Delivered    | Q3 '24              | [Issue 1801](https://github.com/OpenFn/lightning/issues/1801) | Enable a new trigger type that allows users to run workflows based on messages from a Kafka cluster.                                                                                                                                                    |
+| 9. AI-enabled assitants                                               | Delivered    | Q3 '24              | [Issue 2193](https://github.com/OpenFn/lightning/issues/2193) | LLM based AI assitant that supports users with job writing, debugging and co-piloting their workflow design process.                                                                                                                                    |
+| 10. Invite new users as collaborators                                 | Delivered    | Q3 '24              | [Issue 1835](https://github.com/OpenFn/lightning/issues/1835) | Invite users who do not have OpenFn accounts to projects as collaborators.                                                                                                                                                                              |
+| 11. Allow users to create projects                                    | In dev       | Q3 '24              | [Issue 1700](https://github.com/OpenFn/Lightning/issues/1700) | All users to create new projects from their dashboard.                                                                                                                                                                                                  |
+| 12. Control log outputs                                               | Planned      | Q3 '24              | [Issue 1755](https://github.com/OpenFn/Lightning/issues/1755) | Control what is printed in run logs by specifying log levels and allow users to disable printing console.logs, for data privacy once workflows are handling production data.                                                                            |
+| 13. Allow users to export workorder history                           | Planned      | Q3 '24              | [Issue 1698](https://github.com/OpenFn/lightning/issues/1698) | Allow project users to be able to export workorder history. The workorder history contains ALL logs and data clips (Input and Output) associated with runs in a workorder.                                                                              |
+| 14. Enable manual workflow triggers                                   | Not started  | Q4 '24              | [Issue 2155](https://github.com/OpenFn/lightning/issues/2155) | Enable users to manually trigger workflow with JSON/CSV data as input data clip                                                                                                                                                                         |
+| 15. Project datastores and buffers                                    | Not started  | Q4 '24              | [Issue 2190](https://github.com/OpenFn/lightning/issues/2190) | Allow users to configure a data store or buffer that allows temporary of storage of data that can be used in a workflow.                                                                                                                                |
+| 16. Redesign workflow canvas and inspector interface                  | Not started  | Q4 '24              | [Issue 2021](https://github.com/OpenFn/lightning/issues/2021) | Make workflow design better to help user build workflow faster and easier.                                                                                                                                                                              |
+| 17. Improved workorder history page filter                            | Not started  | Q4 '24              | [Issue 1791](https://github.com/OpenFn/lightning/issues/1791) | Extend workorder history page and enable cascading filtering. This is useful for debuging, failure recovery and auditability of the workflow.                                                                                                           |
+| 18. Workflow Monitoring                                               | Not started  | Q4 '24              | [Issue 608](https://github.com/OpenFn/kit/issues/608)         | Give users better visibility of what's happening on inside the worker, especially when an error occurs during run execution.                                                                                                                            |
+| 19. Expanded Audit Trail and Node Authentication (ATNA) functionality | Not started  | Q1 '25              | [Issue 271](https://github.com/OpenFn/Lightning/issues/271)   | Extend audit trail functionality to cover more aspects of ATNA, reference [OpenHIE IOL requirement IOLWF-1](https://guides.ohie.org/arch-spec/openhie-component-specifications-1/openhie-interoperability-layer-iol#openhie-iol-workflow-requirements). |
 
 _You can follow Lightning's progress and track delivered features in the
 [Lightning Changelog](https://github.com/OpenFn/Lightning/blob/main/CHANGELOG.md)._
@@ -114,6 +126,7 @@ workflow engine, enable automated workflows that cut across digital systems.
 ### Have questions, feedback or found a bug?
 
 We encourage users to post their questions on the OpenFn Community at
-[community.openfn.org](https://community.openfn.org), or consider creating 
-issues for bugs via product repository. You can also independetly start contributing
-to the OpenFn software, adaptors, or documentation by getting started [here](./writing-code.md)).
+[community.openfn.org](https://community.openfn.org), or consider creating
+issues for bugs via product repository. You can also independetly start
+contributing to the OpenFn software, adaptors, or documentation by getting
+started [here](./writing-code.md)).

--- a/docs/contribute/openfn-roadmap.md
+++ b/docs/contribute/openfn-roadmap.md
@@ -1,38 +1,85 @@
 ---
-title: Roadmap and Product Management
+title: Roadmap and Product Ethos
 sidebar_label: Roadmap
 ---
 
-### Introduction
+## Introduction
 
 This page details the planned roadmaps for the key products in the OpenFn
-product suite. This includes Lightning, Adaptors, and Docs. We periodically
-review the roadmap to keep it reaser up to date with the development status of
-the features highlighted on the roadmap.
+product suite, including Lightning, Adaptors, and this Docs site. While this
+page will be updated periodically, you can track our realtime roadmap and
+progress [here](#what-are-we-currently-working-on).
 
-### Our approach to product development
+## Our approach to product development
 
-At OpenFn, we have adopted [ShapeUp methodology](https://basecamp.com/shapeup)
-to help our small product and engineeting team build products faster without
-compomising on quality. With ShapeUp in place, we typcially commit to _projects_
-that can be delivered in a 4-6 weeks period with multiple releases based on QA
-approval within the building cycle. We also proiritize feedback and feature
-requests from our users over features in the backlog.
+At OpenFn, we follw the [Shape Up approach](https://basecamp.com/shapeup) to
+help our small engineering team build _meaningul_ products and features faster
+without compomising on quality. With Shape Up in place, we typcially commit to
+_projects_ that can be delivered in a 4-6 week period with multiple releases
+based on QA approval within the building cycle. We also proiritize feedback and
+feature requests from our users over features in the backlog.
 
-### Feature Requests
+:::success Transparency and building what matters
+
+Note that it's fairly rare for us to commit to delivering a specific feature
+more than 2 or 3 months in the future. We are committed to constantly evluating
+what our user base needs most and spending the few resources we have to deliver
+value to them—we simply can't guarantee that what sounds like the "7th most
+important feature to build" now will still be on our list in 6 months.
+
+At the same time, we strive to be as transparent and inclusive as we can in our
+planning processes. We have a big backlog of feature requests and GitHub issues
+(bug reports, stubs, even partially shaped epics or projects) that are getting
+voted up, commented on, and used as inspiration when we're deciding what to
+prioritize next.
+
+Read on to learn more about how we work, how you can see what's coming, and how
+you can get involved!
+
+:::
+
+## What are we currently working on?
+
+All of our team's work is tracked publicly using a GitHub Project. Three key
+views give you up-to-the-minute insights on what we're doing and what's on our
+immediate roadmap.
+
+### See [**_Now_**](https://github.com/orgs/OpenFn/projects/3/views/1) 🚧 for what's been funded and is currently being built
+
+### See [**_Next_**](https://github.com/orgs/OpenFn/projects/3/views/2) 📝 for what's being shaped and _may_ be funded in the next cycle
+
+### See [**_Epics_**](https://github.com/orgs/OpenFn/projects/3/views/7) 🤔 for a list of projects that we're considering, roughly-prioritized
+
+### See [**_Bugs_**](https://github.com/orgs/OpenFn/projects/3/views/7) 🐞 for reported bugs
+
+We will update this site periodically (ideally after each cycle, typically
+lasting between 2-6 weeks) to reflect our progress on major items. You can also
+keep track of all new features, changes, and bug fixes in our
+[Changelog](https://openfn.github.io/lightning/changelog.html).
+
+## How to **get involved**
 
 We use [Canny](https://openfn.canny.io/feature-requests) to receive, track,
 engage and manage new feature requests from the community of users of OpenFn
 globally whilst giving users the ability to the upvote their favoritie and
 mission critical feature request.
 
-#### How to request a new feature
+### Upvote features 👍
 
-1. Go to [https://openfn.canny.io](https://openfn.canny.io/feature-requests)
-2. Provide a very clear, concise and descriptive title for the feature e.g. Make
-   roadmap avaialble in French
-3. Describe this feature in detail
-4. Share this new feature request on the OpenFn community and across your
+1. Go to [openfn.canny.io](https://openfn.canny.io/feature-requests)
+2. Scroll down or use the filter and search features to see existing feature
+   requests
+3. Click on the (^) beside the request to upvote
+4. If you want more upvotes for this feature request, share a link to the
+   feature with your network
+
+### Request a new feature 💡
+
+1. Go to [openfn.canny.io](https://openfn.canny.io/feature-requests)
+2. Provide a very clear, concise and descriptive title for the feature (e.g.,
+   "Make the new workflow button green")
+3. Describe the feature request in detail and why it's important to you
+4. Share the feature request on the OpenFn community and across your
    professional network for upvotes
 
 :::info Tip
@@ -43,29 +90,25 @@ insights from _if they exist_.
 
 :::
 
-#### How to upvote features
+### Open an issue or bug directly
 
-1. Go to [https://openfn.canny.io](https://openfn.canny.io/feature-requests)
-2. Scroll down or use the filter and search features to see existing feature
-   requests
-3. Click on the (^) beside the request to upvote. _Upvoted feature requests are
-   prioritized for development_
-4. If you want more upvotes for this feature request, you can also share across
-   your network
+If you prefer the direct approach, you can search across all tracked issues in
+OpenFn's GitHub org [here](https://github.com/OpenFn), comment on them, or even
+pick them up to work on yourself. If you don't find what you're looking for,
+please go ahead an create an issue in the relevant repo. We'll do our best to
+respond promptly!
 
-### What are we currently working on?
+## Summary Roadmaps
 
-Interested in keeping up with our work? Visit our
-[Current Cycle GitHub board](https://github.com/orgs/OpenFn/projects/3/views/1)
-to see what we are currently busy with and what's coming in the current cycle.
+#### How to interpret `Status` values in the roadmap
 
-### Key for the Roadmap `Status` Values
-
-| Status Value  | Definition                                                              |
-| ------------- | ----------------------------------------------------------------------- |
-| `Not started` | Issue in the backlog but still in need of being designed and scoped out |
-| `Planned`     | Scoped and ready to be picked up by an engineer                         |
-| `In dev`      | Currently being worked on by an engineer                                |
+- `Tracked` means we're thinking about this, but it hasn't been
+  designed/scoped/shaped
+- `Shaped` means it's been scoped and ready to be picked up by an engineer
+- `In dev` means it's currently being worked on by an engineer (see
+  [_NOW_](#what-are-we-currently-working-on))
+- `Delivered` means it's been released (see
+  [Changelog](https://openfn.github.io/lightning/changelog.html))
 
 ### Lightning Roadmap
 
@@ -86,17 +129,17 @@ core of the OpenFn Digital Public Good (learn more about the product
 | 9. AI-enabled assitants                                               | Delivered    | Q3 '24              | [Issue 2193](https://github.com/OpenFn/lightning/issues/2193) | LLM based AI assitant that supports users with job writing, debugging and co-piloting their workflow design process.                                                                                                                                    |
 | 10. Invite new users as collaborators                                 | Delivered    | Q3 '24              | [Issue 1835](https://github.com/OpenFn/lightning/issues/1835) | Invite users who do not have OpenFn accounts to projects as collaborators.                                                                                                                                                                              |
 | 11. Allow users to create projects                                    | In dev       | Q3 '24              | [Issue 1700](https://github.com/OpenFn/Lightning/issues/1700) | All users to create new projects from their dashboard.                                                                                                                                                                                                  |
-| 12. Control log outputs                                               | Planned      | Q3 '24              | [Issue 1755](https://github.com/OpenFn/Lightning/issues/1755) | Control what is printed in run logs by specifying log levels and allow users to disable printing console.logs, for data privacy once workflows are handling production data.                                                                            |
-| 13. Allow users to export workorder history                           | Planned      | Q3 '24              | [Issue 1698](https://github.com/OpenFn/lightning/issues/1698) | Allow project users to be able to export workorder history. The workorder history contains ALL logs and data clips (Input and Output) associated with runs in a workorder.                                                                              |
-| 14. Enable manual workflow triggers                                   | Not started  | Q4 '24              | [Issue 2155](https://github.com/OpenFn/lightning/issues/2155) | Enable users to manually trigger workflow with JSON/CSV data as input data clip                                                                                                                                                                         |
-| 15. Project datastores and buffers                                    | Not started  | Q4 '24              | [Issue 2190](https://github.com/OpenFn/lightning/issues/2190) | Allow users to configure a data store or buffer that allows temporary of storage of data that can be used in a workflow.                                                                                                                                |
-| 16. Redesign workflow canvas and inspector interface                  | Not started  | Q4 '24              | [Issue 2021](https://github.com/OpenFn/lightning/issues/2021) | Make workflow design better to help user build workflow faster and easier.                                                                                                                                                                              |
-| 17. Improved workorder history page filter                            | Not started  | Q4 '24              | [Issue 1791](https://github.com/OpenFn/lightning/issues/1791) | Extend workorder history page and enable cascading filtering. This is useful for debuging, failure recovery and auditability of the workflow.                                                                                                           |
-| 18. Workflow Monitoring                                               | Not started  | Q4 '24              | [Issue 608](https://github.com/OpenFn/kit/issues/608)         | Give users better visibility of what's happening on inside the worker, especially when an error occurs during run execution.                                                                                                                            |
-| 19. Expanded Audit Trail and Node Authentication (ATNA) functionality | Not started  | Q1 '25              | [Issue 271](https://github.com/OpenFn/Lightning/issues/271)   | Extend audit trail functionality to cover more aspects of ATNA, reference [OpenHIE IOL requirement IOLWF-1](https://guides.ohie.org/arch-spec/openhie-component-specifications-1/openhie-interoperability-layer-iol#openhie-iol-workflow-requirements). |
+| 13. Allow users to export workorder history                           | Shaped       | Q3 '24              | [Issue 1698](https://github.com/OpenFn/lightning/issues/1698) | Allow project users to be able to export workorder history. The workorder history contains ALL logs and data clips (Input and Output) associated with runs in a workorder.                                                                              |
+| 12. Control log outputs                                               | Tracked      | Q3 '24              | [Issue 1755](https://github.com/OpenFn/Lightning/issues/1755) | Control what is printed in run logs by specifying log levels and allow users to disable printing console.logs, for data privacy once workflows are handling production data.                                                                            |
+| 14. Enable manual workflow triggers                                   | Tracked      | Q4 '24              | [Issue 2155](https://github.com/OpenFn/lightning/issues/2155) | Enable users to manually trigger workflow with JSON/CSV data as input data clip                                                                                                                                                                         |
+| 15. Project datastores and buffers                                    | Tracked      | Q4 '24              | [Issue 2190](https://github.com/OpenFn/lightning/issues/2190) | Allow users to configure a data store or buffer that allows temporary of storage of data that can be used in a workflow.                                                                                                                                |
+| 16. Redesign workflow canvas and inspector interface                  | Tracked      | Q4 '24              | [Issue 2021](https://github.com/OpenFn/lightning/issues/2021) | Make workflow design better to help user build workflow faster and easier.                                                                                                                                                                              |
+| 17. Improved History page filter                                      | Tracked      | Q4 '24              | [Issue 1791](https://github.com/OpenFn/lightning/issues/1791) | Extend workorder history page and enable cascading filtering. This is useful for debuging, failure recovery and auditability of the workflow.                                                                                                           |
+| 18. Enhanced websocket worker Monitoring                              | Tracked      |                     | [Issue 608](https://github.com/OpenFn/kit/issues/608)         | Give users better visibility of what's happening on inside the worker, especially when an error occurs during run execution.                                                                                                                            |
+| 19. Expanded Audit Trail and Node Authentication (ATNA) functionality | Tracked      |                     | [Issue 271](https://github.com/OpenFn/Lightning/issues/271)   | Extend audit trail functionality to cover more aspects of ATNA, reference [OpenHIE IOL requirement IOLWF-1](https://guides.ohie.org/arch-spec/openhie-component-specifications-1/openhie-interoperability-layer-iol#openhie-iol-workflow-requirements). |
 
 _You can follow Lightning's progress and track delivered features in the
-[Lightning Changelog](https://github.com/OpenFn/Lightning/blob/main/CHANGELOG.md)._
+[Changelog](https://openfn.github.io/lightning/changelog.html)._
 
 ### Adaptors Roadmap
 
@@ -123,10 +166,10 @@ workflow engine, enable automated workflows that cut across digital systems.
 | 5. Template Shared Health Record Workflows                  | Not started  | 2024                | [See OpenHIE docs](https://guides.ohie.org/arch-spec/introduction/shared-health-record); to be hosted on demo.openfn.org                      | To demonstrate how OpenFn can allow external systems to automatically save and retrieve information from the HIE (from the OpenHIE standard spec)                                                                                                                  |
 | 6. Template Aggregate Reporting Workflows                   | Not started  | 2024                | [See OpenHIE docs](https://guides.ohie.org/arch-spec/introduction/aggregate-reporting-workflows); to be hosted on demo.openfn.org             | To demonstrate how OpenFn can support aggregate data exchange of health indicators, leveraging the [ADX](https://wiki.ihe.net/index.php/Aggregate_Data_Exchange) data standard                                                                                     |
 
-### Have questions, feedback or found a bug?
+## Have questions, feedback or found a bug?
 
 We encourage users to post their questions on the OpenFn Community at
 [community.openfn.org](https://community.openfn.org), or consider creating
 issues for bugs via product repository. You can also independetly start
 contributing to the OpenFn software, adaptors, or documentation by getting
-started [here](./writing-code.md)).
+started [here](./writing-code.md).


### PR DESCRIPTION
- Removed the warning header
- Updated with the links to Canny and GitHub
- Added instructions on how to request and upvote feature requests.