### PR TITLE
All users have a billing account

### DIFF
--- a/docs/hosted/overview.md
+++ b/docs/hosted/overview.md
@@ -19,10 +19,6 @@ given access to a single project on the free tier and we create a personal
 billing account (see [below](#billing-accounts)) which you can later use to
 purchase additional project spaces or upgrade from the free plan.
 
-If you've been invited to join OpenFn.org as a collaborator for another user's
-project, you won't yet have your own personal billing account but may request
-one by writing to support@openfn.org.
-
 ## Billing Accounts
 
 All projects _belong_ to a single billing account. The billing account houses


### PR DESCRIPTION
This PR removes the note that says invited users do not have billing accounts.  We have a fix for that in v2.7.14 (1.2.12) , so the note is removed. 