### PR TITLE
Showcase support for file paths in `project-spec.yaml`

### DIFF
--- a/docs/deploy/portability-versions.md
+++ b/docs/deploy/portability-versions.md
@@ -5,197 +5,13 @@ title: Versions of the Portability Proposal
 OpenFn is currently designing a portable project configuration schema that can
 be used to import or export projects between OpenFn/platform and OpenFn/engine.
 
-## Proposal v4
+## [Current](/documentation/deploy/portability#the-project-spec)
 
-The portability specification v4 defines how entire projects (groups of
-workflows with their associated triggers, credentials and jobs) can be
-represented as code. This specification has been written for
-[Lightning](/documentation#our-products/#lightning-coming-soon),
-the fully open source webb app which extends the OpenFn DPG. It aims to (a)
-improve developer experience, allowing them to build and test workflows locally;
-(b) enable version control and an audit trail of project changes; and (c) enable
-users to port existing workflows from the OpenFn platform to Lightning.
+[See the current specification here.](/documentation/deploy/portability#the-project-spec)
 
-This new specification has been designed and documented thanks to support from a
-Digital Square Global Goods grant.
+## v2
 
-The `project.zip` structure and files:
-
-```
-/globals
-   sample-clinic-map.json
-   sample-translations.json
-/workflow-a
-   job-1.js
-   job-2.js
-   job-3.js
-/workflow-b
-   job-4.js
-project.yaml
-project.state.yaml
-```
-
-The `project.yaml`:
-
-```yaml
-name: "My Project" # The project name
-
-globals: # All global constants accessible to this project
-  clinic-map: file://./globals/clinic-map.json
-  project-expense-codes: file://./globals/project-expense-codes.json
-  service-codes:
-    body:
-      m126: Medical Referral
-      g01: General Checkup
-      ps: Psycho-social Support
-
-workflows: # All workflows in a project
-  CommCare-to-OpenMRS: #The workflow name. Workflow names won't have spaces
-    jobs: # All jobs/steps in a workflow
-      Coerce-to-FHIR: # The job/step name
-        trigger: webhook #webhook urls are uids so are not included
-        adaptor: language-fhir
-        enabled: true
-        credential: my-fihr-credential #looks up credential in state by its name
-        # when running locally, the credentials values are taken from the overrides file
-        # cli run workflow "CommCare-to-OpenMRS" --overrides ./keys-and-values.yaml
-        body: "file://./CommCare-to-OpenMRS/Coerce-to-FHIR.js" # each job job-body is stored in a separate file, within a folder for the whole workflow
-
-      Load-to-openmrs:
-        trigger:
-          on-success: Coerce-to-FHIR
-        adaptor: language-openmrs
-        credential: my-other-credential
-        enabled: true
-        body:
-          # no "include", but pathlike doesn't work: if you're doing a uri you need to be explicit about it
-          # default to local fs -- no numbering because too complicated if users change the order
-          "file://./CommCare-to-OpenMRS/Load-to-openmrs.js"
-
-      Send-Wrap-Up-Reports:
-        trigger:
-          on-success: Load-to-openmrs
-        enabled: true
-        adaptor: language-mailgun
-        globals:
-          - service-codes
-          - clinic-map
-        body: >
-          # this triggers a new workflow
-          fn(state => state)
-          sendEmail(state => state.emailContent)
-
-  Kobo-to-DHIS2: #This is a second workflow
-    Fetch-Kobo-Submissions:
-      trigger:
-        cron: * 5 * * *
-      enabled: true
-      adaptor: language-kobotoolbox
-      body: "file://./Kobo-to-DHIS2/Fetch-Kobo-Submissions.js"
-
-    Upload-to-DHIS2:
-      trigger:
-        on-success: Fetch-Kobo-Submissions
-      adaptor: language-kobotoolbox
-      enabled: false
-      body: "file://./Kobo-to-DHIS2/Upload-to-DHIS2.js"
-```
-
-The `project.state.yaml`:
-
-```yaml
-project:
-  - id: '45bffee'
-    key: 'My Project'
-
-globals:
-  - id: 'sj23n36'
-    key: 'clinic-map'
-  - id: 'bss522g'
-    key: 'project-expense-codes'
-  - id: '22aa4st'
-    key: 'service-codes'
-
-workflows:
-  - id: 'cfd7c68'
-    key: 'CommCare-to-OpenMRS' # this is the NAME and the KEY
-  - id: 'd1ecc4f'
-    key: 'Kobo-to-DHIS2'
-
-jobs:
-  - id: 'ns6yw54'
-    key: 'Coerce-to-FHIR'
-  - id: '12bs52j'
-    key: 'Load-to-openmrs'
-  - id: 'lk81hs6'
-    key: 'Send-Wrap-Up-Reports'
-
-  - id: 'sn26sh2'
-    key: 'Fetch-Kobo-Submissions'
-  - id: 'sk1722h'
-    key: 'Upload-to-DHIS2'
-
-credentials:
-  - id: '12ms62y'
-    key: 'My FHIR Credential'
-```
-
-## Proposal v3
-
-v3 introduces
-[URI schemes](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-`file://`, `https://`, `gcs://`
-
-```yaml
-jobs:
-  job-1:
-    expression: 'file://my-job.js' # URIs may be used (e.g., https://raw.githubusercontent.com/org/repo/my-job.js)
-    adaptor: '@openfn/language-common'
-    trigger: trigger-1
-    credential: my-secret-credential
-  recurring-job:
-    expression: >
-      fn(state => {
-        console.log("Hi there!")
-        return state;
-      })
-    adaptor: '@openfn/language-common'
-    trigger: every-minute
-  flow-job:
-    expression: >
-      fn(state => {
-        state.data.number = state.data.number * 3
-        return state;
-      })
-    adaptor: '@openfn/language-common'
-    trigger: after-j1
-  catch-job:
-    expression: >
-      fn(state => {
-        state.message = "handled it."
-        return state;
-      })
-    adaptor: '@openfn/language-common'
-    trigger: j1-fails
-
-triggers:
-  trigger-1:
-    criteria: '{"number":2}'
-  every-minute:
-    cron: '* * * * *'
-  after-j1:
-    success: job-1
-  j1-fails:
-    failure: job-1
-
-credentials:
-  my-secret-credential:
-    username: '******' # Credential keys get exported, but values must be manually reentered
-    password: '******'
-  my-other-credential: 'file://gcp_credential.json' # And URIs may be specified directly for the credential body
-```
-
-## Proposal v2
+Used for export from the legacy platform.
 
 ```yaml
 jobs:
@@ -251,7 +67,9 @@ credentials:
     password: '******'
 ```
 
-## Proposal v1
+## v1
+
+Initial portability proposal
 
 ```js
 const project = {

--- a/docs/deploy/portability.md
+++ b/docs/deploy/portability.md
@@ -30,7 +30,7 @@ Lightning.
 
 ### The project "spec"
 
-The project specification (or "spec") is often saved as a `project.yaml` file.
+The project specification (or "spec") is often saved as a `project.yaml` file. This spec now supports 2 ways of defining job bodies: inline, or as an object referencing an external file.
 
 ```yaml
 name: openhie-project
@@ -68,8 +68,8 @@ workflows:
         enabled: true
         # credential:
         # globals:
-        body: |
-          fn(state => state);
+        body:
+          path: ./job-bodies/notify-success.js
 
       Notify-CHW-upload-failed:
         name: Notify-CHW-upload-failed
@@ -77,8 +77,8 @@ workflows:
         enabled: true
         # credential:
         # globals:
-        body: |
-          fn(state => state);
+        body:
+          path: ./job-bodies/notify-failure.j
 
     triggers:
       webhook:
@@ -101,6 +101,20 @@ workflows:
         target_job: Notify-CHW-upload-failed
         condition: on_job_failure
 ```
+
+In this spec, you can see the two different ways to define a job's body:
+
+1. Inline body:
+Used in the `FHIR-standard-Data-with-change` and `Send-to-OpenHIM-to-route-to-SHR` job. The body is directly written in the YAML file.
+
+2. External file reference:
+Used in both Notify-CHW-upload-successful and Notify-CHW-upload-failed jobs. The body is stored in separate files, referenced by the path key. This allows for better organization of complex job logic.
+
+When using file paths:
+
+- Paths are relative to the location of the `project.yaml` file.
+- Ensure that the referenced files exist and contain valid job body code.
+- This method is particularly useful for complex jobs or when you want to reuse job bodies across different projects.
 
 ### The project "state"
 

--- a/docs/deploy/portability.md
+++ b/docs/deploy/portability.md
@@ -30,7 +30,7 @@ Lightning.
 
 ### The project "spec"
 
-The project specification (or "spec") is often saved as a `project.yaml` file. This spec now supports 2 ways of defining job bodies: inline, or as an object referencing an external file.
+The project specification (or "spec") is often saved as a `project.yaml` file. The spec now supports 2 ways of defining job bodies: inline, or as an object referencing an external file.
 
 ```yaml
 name: openhie-project
@@ -105,10 +105,10 @@ workflows:
 In this spec, you can see the two different ways to define a job's body:
 
 1. Inline body:
-Used in the `FHIR-standard-Data-with-change` and `Send-to-OpenHIM-to-route-to-SHR` job. The body is directly written in the YAML file.
+Used in the `FHIR-standard-Data-with-change` and `Send-to-OpenHIM-to-route-to-SHR` jobs. The body is directly written in the YAML file.
 
 2. External file reference:
-Used in both Notify-CHW-upload-successful and Notify-CHW-upload-failed jobs. The body is stored in separate files, referenced by the path key. This allows for better organization of complex job logic.
+Used in both `Notify-CHW-upload-successful` and `Notify-CHW-upload-failed` jobs. The body is stored in separate files, referenced by the path key. This allows for better organization of complex job logic.
 
 When using file paths:
 

--- a/docs/deploy/portability.md
+++ b/docs/deploy/portability.md
@@ -59,7 +59,6 @@ credentials:
   jane-smith@test.com-HAPI-FHIR:
     owner: jane-smith@test.com
     name: HAPI FHIR
-# globals:
 workflows:
   OpenHIE-Workflow:
     name: OpenHIE Workflow
@@ -69,7 +68,6 @@ workflows:
         adaptor: '@openfn/language-http@latest'
         enabled: true
         credential: null
-        # globals:
         body:
           path: ./jobs/my-fancy-script.js
 
@@ -78,7 +76,6 @@ workflows:
         adaptor: '@openfn/language-http@latest'
         enabled: true
         credential: jane-smith@test.com-HAPI-FHIR
-        # globals:
         body: |
           fn(state => {
             console.log("hello github integration")
@@ -90,7 +87,6 @@ workflows:
         adaptor: '@openfn/language-http@latest'
         enabled: true
         credential: null
-        # globals:
         body: fn(state => state);
 
       Notify-CHW-upload-failed:
@@ -98,7 +94,6 @@ workflows:
         adaptor: '@openfn/language-http@latest'
         enabled: true
         credential: null
-        # globals:
         body:
           path: ./jobs/notify-failure.js
 

--- a/docs/deploy/portability.md
+++ b/docs/deploy/portability.md
@@ -18,24 +18,47 @@ If you're interested in contributing to the specification, reach out to OpenFn
 via the [community forum](https://community.openfn.org), write to us, or suggest
 changes by submitting a pull request here.
 
-## "Projects as code"
+## Projects "as code"
 
-The portability specification v4 defines how entire projects (groups of
-workflows with their associated triggers, edges, credentials and jobs) can be
-represented as code. It improves the OpenFn developer experience, allowing
-workflows to be built and tested locally; (b) enables project version control
-and an audit trail of project changes; and (c) allows users to port existing
-workflows from OpenFn v1 to v2, as well as between instances or deployments of
-Lightning.
+Entire projects (groups of workflows with their associated triggers, edges,
+credentials and jobs) can be represented as code. This improves the OpenFn
+developer experience by (a) allowing workflows to be built and tested locally;
+(b) enabling project version control and an audit trail of project changes; and
+(c) allowing users to port existing projects between different instances (i.e.,
+deployments) of Lightning.
 
-### The project "spec"
+### Directory structure
 
-The project specification (or "spec") is often saved as a `project.yaml` file. The spec now supports 2 ways of defining job bodies: inline, or as an object referencing an external file.
+Many users keep OpenFn projects in git repositories, and this is a common
+structure:
+
+```
+myProject/
+├── workflow-a/
+│   ├── job-1.js
+│   ├── job-2.js
+│   └── job-3.js
+├── workflow-b/
+│   └── job-4.js
+├── project.yaml
+├── projectState.json
+└── config.json
+```
+
+### The project **_spec_**
+
+The project specification (or "spec") is often saved as a `project.yaml` file.
+While most of the spec is written inline, many developers prefer to track their
+job bodies in separate `.js` files and they then reference them with a relative
+path.
 
 ```yaml
 name: openhie-project
 description: Some sample
-# credentials:
+credentials:
+  jane-smith@test.com-HAPI-FHIR:
+    owner: jane-smith@test.com
+    name: HAPI FHIR
 # globals:
 workflows:
   OpenHIE-Workflow:
@@ -45,40 +68,39 @@ workflows:
         name: FHIR-standard-Data-with-change
         adaptor: '@openfn/language-http@latest'
         enabled: true
-        # credential:
+        credential: null
         # globals:
-        body: |
-          fn(state => {
-            console.log("hello github integration")
-            return state
-        });
+        body:
+          path: ./jobs/my-fancy-script.js
 
       Send-to-OpenHIM-to-route-to-SHR:
         name: Send-to-OpenHIM-to-route-to-SHR
         adaptor: '@openfn/language-http@latest'
         enabled: true
-        # credential:
+        credential: jane-smith@test.com-HAPI-FHIR
         # globals:
         body: |
-          fn(state => state);
+          fn(state => {
+            console.log("hello github integration")
+            return state
+          });
 
       Notify-CHW-upload-successful:
         name: Notify-CHW-upload-successful
         adaptor: '@openfn/language-http@latest'
         enabled: true
-        # credential:
+        credential: null
         # globals:
-        body:
-          path: ./job-bodies/notify-success.js
+        body: fn(state => state);
 
       Notify-CHW-upload-failed:
         name: Notify-CHW-upload-failed
         adaptor: '@openfn/language-http@latest'
         enabled: true
-        # credential:
+        credential: null
         # globals:
         body:
-          path: ./job-bodies/notify-failure.j
+          path: ./jobs/notify-failure.js
 
     triggers:
       webhook:
@@ -102,21 +124,25 @@ workflows:
         condition: on_job_failure
 ```
 
-In this spec, you can see the two different ways to define a job's body:
+In this spec, you can see the different ways of defining a job's body:
 
-1. Inline body:
-Used in the `FHIR-standard-Data-with-change` and `Send-to-OpenHIM-to-route-to-SHR` jobs. The body is directly written in the YAML file.
+1. Inline body: Used in the `FHIR-standard-Data-with-change` and
+   `Send-to-OpenHIM-to-route-to-SHR` jobs. The body is directly written in the
+   YAML file.
 
-2. External file reference:
-Used in both `Notify-CHW-upload-successful` and `Notify-CHW-upload-failed` jobs. The body is stored in separate files, referenced by the path key. This allows for better organization of complex job logic.
+2. External file reference: Used in both `Notify-CHW-upload-successful` and
+   `Notify-CHW-upload-failed` jobs. The body is stored in separate files,
+   referenced by the path key. This allows for better organization of complex
+   job logic.
 
 When using file paths:
 
 - Paths are relative to the location of the `project.yaml` file.
 - Ensure that the referenced files exist and contain valid job body code.
-- This method is particularly useful for complex jobs or when you want to reuse job bodies across different projects.
+- This method is particularly useful for complex jobs or when you want to reuse
+  job bodies across different projects.
 
-### The project "state"
+### The project **_state_**
 
 The project state is a representation of a particular project as _on a specific
 Lightning instance_. It is often saved as `projectState.json` and contains UUIDs
@@ -124,6 +150,20 @@ for resources on a particular Lightning deployment.
 
 ```json
 {
+  "id": "8deff39d-8189-4bd7-9dc7-f9f08e7f2c60",
+  "name": "openhie-project",
+  "description": null,
+  "inserted_at": "2023-08-25T08:57:31",
+  "updated_at": "2023-08-25T08:57:31",
+  "scheduled_deletion": null,
+  "requires_mfa": false,
+  "project_credentials": {
+    "jane-smith@test.com-HAPI-FHIR": {
+      "id": "25f48989-d349-4eb8-99c3-923ebba5b116",
+      "name": "HAPI FHIR",
+      "owner": "jane-smith@test.com"
+    }
+  },
   "workflows": {
     "OpenHIE-Workflow": {
       "id": "27ae2937-0959-48b8-a597-b1646aae8c14",
@@ -219,13 +259,11 @@ for resources on a particular Lightning deployment.
         }
       }
     }
-  },
-  "id": "8deff39d-8189-4bd7-9dc7-f9f08e7f2c60",
-  "name": "openhie-project"
+  }
 }
 ```
 
-### Using the CLI to deploy or describe projects projects as code
+## Using the CLI interact with projects
 
 The project spec and project state can be used for a variety of reasons, e.g.
 one could generate the state and spec as backups of the project or one could
@@ -233,7 +271,9 @@ generate these files and use them for auditing and record keeping, etc. The
 OpenFn [CLI](https://github.com/OpenFn/kit/tree/main/packages/cli) comes with
 commands that can be used to pull project configurations down from a running
 Lightning server, and to deploy or push updates to existing projects on a
-Lightning server. To learn more about automated version control via pull and deploy, head over to our [Version Control](../manage-projects/link-to-gh.md) docs.
+Lightning server. To learn more about automated version control via pull and
+deploy, head over to our [Version Control](../manage-projects/link-to-gh.md)
+docs.
 
 :::info Don't have the CLI yet?
 
@@ -270,7 +310,7 @@ Or through a `config.json` file:
 More details on the CLI can be found
 [here](https://github.com/OpenFn/kit/tree/main/packages/cli#basic-usage).
 
-### `openfn pull` to generate a project spec and state
+### `openfn pull` to generate spec & state
 
 To generate the spec and state files for an existing project, use:
 
@@ -281,7 +321,7 @@ openfn pull {YOUR-PROJECT-UUID} -c ./config.json
 This command will save (or overwrite) a project spec and state file based on the
 path you've set in your configuration.
 
-### `openfn deploy` to create a project on a Lightning instance
+### `openfn deploy` to create new projects
 
 To deploy a new project to a Lightning instance from a project spec (without a
 project state) file use:
@@ -290,7 +330,7 @@ project state) file use:
 openfn deploy -c config.json
 ```
 
-### `openfn deploy` to update an existing project
+### `openfn deploy` to update existing projects
 
 With a valid project state defined in your `config.json`, the same
 `openfn deploy` command will beam up your changes as described by a difference
@@ -321,7 +361,7 @@ Project found.
 [CLI] ♦ Deployed.
 ```
 
-### Getting Help with the cli
+## Getting Help with the cli
 
 The cli package comes with an inbuilt `help`. Adding `--help` to a command such
 as `openfn deploy --help` will result in a help message describing the command
@@ -347,8 +387,5 @@ Options:
 
 ## Other Versions
 
-- [Portability Proposal v4](portability-versions#proposal-v4)
-- [Portability Proposal v3](portability-versions#proposal-v3)
-- [Portability Proposal v2](portability-versions#proposal-v2) (`@latest` for
-  platform-app/microservice compatibility.)
-- [Portability Proposal v1](portability-versions#proposal-v1)
+- [Portability Spec v2](portability-versions#v2)
+- [Portability Spec v1](portability-versions#v1)

--- a/docs/get-started/terminology.md
+++ b/docs/get-started/terminology.md
@@ -31,8 +31,8 @@ workflow configuration & history. Projects have an owner and one or more
 Collaborators.
 
 In local deployment and development, Project also corresponds to a
-[`project.yaml`](/documentation/deploy/portability-versions#proposal-v2)
-file, which defines a project' configuration.
+[`project.yaml`](/documentation/deploy/portability-versions#v2) file, which
+defines a project' configuration.
 
 In either case, a Project contains Workflows, Triggers, Credentials, and
 everything you need to automate and integrate with OpenFn.
@@ -49,11 +49,10 @@ A Workflow is a collection of a Trigger, Steps, Paths, and custom logic
 connected together to automate a specific business process or task. A Workflow
 is configured via the Canvas in the web app, or locally (via code).
 
-OpenFn automation centers around
-[Workflows](/documentation/build/workflows), which may have one or multiple
-Steps. Workflows can be run in real-time (based on an event -e.g., new patient
-registration), on a scheduled basis (e.g., every day at 8am), or manually
-on-demand.
+OpenFn automation centers around [Workflows](/documentation/build/workflows),
+which may have one or multiple Steps. Workflows can be run in real-time (based
+on an event -e.g., new patient registration), on a scheduled basis (e.g., every
+day at 8am), or manually on-demand.
 
 Think of workflow as a set of instructions you might give a staff member (e.g.,
 please create a new Patient record in OpenMRS when a form containing a newly
@@ -103,12 +102,11 @@ Credentials are the **"how to log in"** part of automation!
 
 :::
 
-A Credential is used
-to authenticate with a destination app (e.g., Database username, password &
-login URL) so that a Workflow Step can run. Via OpenFn's security model,
-Credentials are separated from the Workflows themselves to ensure that stored
-usernames and passwords (which are all encrypted) do not get leaked or accessed
-by the wrong people.
+A Credential is used to authenticate with a destination app (e.g., Database
+username, password & login URL) so that a Workflow Step can run. Via OpenFn's
+security model, Credentials are separated from the Workflows themselves to
+ensure that stored usernames and passwords (which are all encrypted) do not get
+leaked or accessed by the wrong people.
 
 ## Trigger
 
@@ -245,7 +243,9 @@ Inputs may be created automatically by a webhook event (e.g., a message
 forwarded or JSON payload posted to OpenFn) or another Workflow Step, or
 manually by an OpenFn user.
 
-Example Input from a form submission from a mobile data collection app (e.g., Kobo, ODK, CommCare):
+Example Input from a form submission from a mobile data collection app (e.g.,
+Kobo, ODK, CommCare):
+
 ```json
 {
   "data": {
@@ -275,18 +275,18 @@ according to the business logic defined in the Step's job expression. Outputs
 are either passed to the next Step in the workflow and/or to the connected
 destination app.
 
-Example Output if that form submission example (see above section) was mapped to a connected case management app: 
+Example Output if that form submission example (see above section) was mapped to
+a connected case management app:
+
 ```json
 {
   "data": {
-    "patient":{
+    "patient": {
       "full_name": "John Doe",
       "age_at_enrollment": 16,
       "type": "new",
       "source": "mobile-app"
-      }
     }
+  }
 }
 ```
-
-

--- a/sidebars-main.js
+++ b/sidebars-main.js
@@ -96,7 +96,6 @@ module.exports = {
             'manage-projects/workflow-dashboard',
             'manage-projects/collaboration',
             'manage-projects/oauth',
-
           ],
         },
         {
@@ -125,12 +124,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Deployment',
-      items: [
-        'deploy/options',
-        'deploy/requirements',
-        'deploy/portability',
-        'deploy/portability-versions',
-      ],
+      items: ['deploy/options', 'deploy/requirements', 'deploy/portability'],
     },
     {
       type: 'category',


### PR DESCRIPTION
The spec now supports 2 ways of defining job bodies: inline, as or as an object referencing an external file.

Depends on: https://github.com/OpenFn/kit/pull/742

