### PR TITLE
don't generate examples for jobs with no expression

### DIFF
--- a/generate-library/index.js
+++ b/generate-library/index.js
@@ -150,21 +150,25 @@ module.exports = function (context, { apiUrl }) {
           console.log('Done ✓');
 
           console.log('Parsing public jobs API data...');
-          jobs.map(j => {
-            const uniqueName = `${j.name.trim()}-${hDate(j.inserted_at)}`
-              .replace(/[^a-z0-9_-]/gi, '-')
-              .replace(/-{2,}/g, '-')
-              .replace(/^[-,\[]/, '');
+          jobs
+            .filter(j => {
+              return j.expression && j.expression !== '// Your job goes here.';
+            })
+            .map(j => {
+              const uniqueName = `${j.name.trim()}-${hDate(j.inserted_at)}`
+                .replace(/[^a-z0-9_-]/gi, '-')
+                .replace(/-{2,}/g, '-')
+                .replace(/^[-,\[]/, '');
 
-            const keywords = getKeywords(j.expression);
-            const body = generateBody(j, uniqueName, keywords);
+              const keywords = getKeywords(j.expression);
+              const body = generateBody(j, uniqueName, keywords);
 
-            pushToPaths(j, uniqueName);
-            fs.writeFileSync(
-              `./adaptors/library/jobs/auto/${uniqueName}.md`,
-              body
-            );
-          });
+              pushToPaths(j, uniqueName);
+              fs.writeFileSync(
+                `./adaptors/library/jobs/auto/${uniqueName}.md`,
+                body
+              );
+            });
           console.log('Done ✓');
 
           console.log('Creating sidebar paths...');


### PR DESCRIPTION
## Short Description

A small tweak to filter out docs examples which don't have code

For example, we should not be showing this example: https://docs.openfn.org/adaptors/library/jobs/auto/Registration-forms-new-case-2023-06-22

This PR filters stuff like this out

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
