### PR TITLE
Add missing state flag to debug example

### DIFF
--- a/docs/build-for-developers/cli-walkthrough.md
+++ b/docs/build-for-developers/cli-walkthrough.md
@@ -460,7 +460,7 @@ fn(state => {
 
 </details>
 
-##### Run **openfn debug.js -a http**
+##### Run **openfn debug.js -a http -s tmp/state.json**
 
 <details>
   <summary>Expected CLI logs</summary>


### PR DESCRIPTION
## Short Description

A small change to the CLI walkthrough to add a missing state flag to an example debug command.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
