### PR TITLE
Add youtube playlist to adapters page

### DIFF
--- a/adaptors/intro.mdx
+++ b/adaptors/intro.mdx
@@ -44,6 +44,12 @@ adaptors is as follows:
 
 In short, _most_ adaptors follow the naming convention `@openfn/language-xyz`.
 
+## Learn More About Adaptors
+
+Explore this YouTube playlist to gain a deeper understanding of OpenFn adaptors.
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?si=mnfXiLEM83eUzADd&amp;list=PL1pD3-abjHJ1cSQAoMd_ODCU_AauvyZeL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ## Adaptors vs. Workflows
 
 Adaptors are reusable components that make connecting with a specific app


### PR DESCRIPTION
## Short Description

This PR adds a section to embed a youtube playlist in the adapter doc.

## Details

The youtube playlist contains a list of videos focused on adapter learning.

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
