### PR TITLE
Fix path for googlesheets and adaptors documentation

### DIFF
--- a/adaptors/googlesheets.md
+++ b/adaptors/googlesheets.md
@@ -2,12 +2,10 @@
 title: Google Forms/Google Sheets
 ---
 
-## Google Sheets Adaptor Overview
+The Google Sheets adaptor provides seamless integration between Google Forms,
+Google Sheets, and the OpenFn platform, enabling robust data flow management.
 
-Google Sheets adaptor provides seamless integration between Google Forms, Google
-Sheets, and the OpenFn platform, enabling robust data flow management.
-
-### Authentication and Authorization
+## Authentication and Authorization
 
 This adaptor requires OAuth authorization to connect with Google Sheets. This
 authorization can be achieved by a user or organization admin consenting to an
@@ -31,7 +29,7 @@ for how to complete the OAuth Client Setup form on OpenFn.
 
 :::
 
-#### Permissions (Scopes)
+### Permissions (Scopes)
 
 Permissions and access in an OAuth instance are defined by scopes which are
 named differently by providers based on their functions within their platform.
@@ -42,17 +40,20 @@ said, please refer to
 [Google's documentation on Oauth scopes](https://developers.google.com/identity/protocols/oauth2/scopes)
 for the latest information.
 
-- `openid`
-- `email`
-- `profile`
-- `https://www.googleapis.com/auth/spreadsheets`
+- **The required endpoints** for the Google Oauth Client are available at
+  https://accounts.google.com/.well-known/openid-configuration.
+- **The mandatory scopes** are `openid email profile`
+- **The optional scopes** are available here:
+  https://developers.google.com/identity/protocols/oauth2/scopes (note that you
+  need to use the full URL, e.g.,
+  `https://www.googleapis.com/auth/spreadsheets`)
 
-### Integration Options
+## Integration Options
 
 There are a couple of primary ways to integrate with this app, each catering to
 different use cases.
 
-#### 1. Pushing Data to OpenFn via Google App Scripts
+### 1. Pushing Data to OpenFn via Google App Scripts
 
 With this method, data from Google Forms or Google Sheets is automatically
 pushed to an OpenFn webhook trigger workflow whenever new entries are made. This
@@ -110,7 +111,7 @@ function onFormSubmit(e) {
 }
 ```
 
-#### 2. Pulling Data from Google Sheets using OpenFn
+### 2. Pulling Data from Google Sheets using OpenFn
 
 Alternatively, you can pull data from Google Sheets at specific intervals or
 on-demand using a `cron` workflow in OpenFn, allowing for more controlled data
@@ -124,7 +125,7 @@ learn how to configure a workflow step to use this OpenFn adaptor to
 **Use Cases:** - Aggregating data for periodic reporting or analysis. -
 Implementing batch processing for efficiency and resource optimization.
 
-#### 3. Pushing Data to Google Sheets via OpenFn
+### 3. Pushing Data to Google Sheets via OpenFn
 
 The Google Sheets adaptor can also be used to push data to Google Sheets from
 other systems via OpenFn. This allows for seamless integration between external

--- a/docs/manage-projects/oauth.md
+++ b/docs/manage-projects/oauth.md
@@ -4,12 +4,6 @@ sidebar_label: OAuth Authentication
 slug: /oauth
 ---
 
-Some applications require OAuth as an authentication method for connecting with
-third party applications making requests via their APIs. This guide walks you
-through how to set up and manage OAuth clients.
-
-### OAuth Authentication
-
 Some applications require [OAuth](https://oauth.net/2/) as an authentication
 method for connecting with third-party applications and making requests via
 their APIs. OpenFn allows you to connect with applications using their OAuth
@@ -17,9 +11,9 @@ authentication. To use this feature in your OpenFn workflows, you need to set up
 OAuth clients and credentials for your instances or projects. This guide walks
 you through the management of OAuth clients and credentials.
 
-### Setting up an OAuth client
+## OAuth Clients
 
-#### What is an OAuth client and when do I need it?
+### What is an OAuth client and when do I need it?
 
 By setting up OAuth for an application, you authorize OpenFn to connect and
 interact with this application within a set of scopes defined by you. For
@@ -80,7 +74,7 @@ the client, or via editing it.
 
 ![OAuth edit](/img/oauth_client_edit.png)
 
-#### Making OAuth clients global
+### Making OAuth clients global
 
 When an OAuth client is global, users in the instance can have access to it and
 can create credentials from it.
@@ -94,7 +88,7 @@ from the client.
 
 ![OAuth project access](/img/manage_project_access.png)
 
-#### Sharing OAuth clients with projects
+### Sharing OAuth clients with projects
 
 To share an OAuth client with specific projects, scroll down to
 `Manage Project Access` section in the OAuth client configuration modal. Select
@@ -102,6 +96,8 @@ the project dropdown and select a project and click the add button to grant the
 project access to the client.
 
 ![Share OAuth client](/img/share_oauth_client.png)
+
+## Oauth Credentials
 
 ### Creating a credential from an OAuth client
 
@@ -157,3 +153,5 @@ Go to the docs on
 [managing user credentials](../manage-users/user-credentials.md) to learn more
 about credential management for the applications you are integrating with on
 OpenFn.
+
+### Example Oauth Client Configuration

--- a/docs/manage-projects/oauth.md
+++ b/docs/manage-projects/oauth.md
@@ -63,8 +63,8 @@ application. (Note: You should substitue `https://app.openfn.org/` with _your_
 OpenFn's deployment base URL if you're not using app.openfn.org.)
 
 For app-specific guidance (e.g., how to set up an Oauth Client
-[for Google Sheets](./adaptors/googlesheets)), refer to the relevant
-[Adaptor documentation](./adaptors) for app-specific guidance
+[for Google Sheets](../adaptors/googlesheets)), refer to the relevant
+[Adaptor documentation](../adaptors) for app-specific guidance
 
 :::
 

--- a/docs/tutorials/http-to-googlesheets.md
+++ b/docs/tutorials/http-to-googlesheets.md
@@ -92,13 +92,22 @@ succeeded, you should see:
 
 ## 3. Configure another Step to transform the data & import your GoogleSheet
 
-Configure an Oauth Client with Google openid using your Google account's email. You can configure it 
-via Project Settings Credentials or on your Credentials via profile menu. 
-The required endpoints for the Google Oauth Client you find it [here](https://accounts.google.com/.well-known/openid-configuration).  
-For mandatory scopes use "openid email profile" (without quotes) and on optional scopes add https://www.googleapis.com/auth/spreadsheets. Make sure your Google user has edit access to the GoogleSheet used on the job.
+Create a new Googlesheet `Credential` using your Google account's email. (Make
+sure this Google user has edit access to the GoogleSheet you want to integrate
+with.)
 
-For this demo, we have created a Googlesheet
-[like this](https://docs.google.com/spreadsheets/d/1gT4cpHSDQp8A_JIX_5lqTLTwV0xBo_u8u3ZNWALmCLc/edit?usp=sharing) to store the `users` data.
+:::info Don't see a GoogleSheets credential option?
+
+If your instance superuser hasn't configured a global Oauth client, you may need
+to set one up for yourself. Learn about Oauth Clients
+[here](/documentation/oauth#oauth-clients) and specifics for a GoogleSheet
+Client [here](/adaptors/googlesheets#permissions-scopes).
+
+:::
+
+For this demo, we configured the Googlesheet
+[like this](https://docs.google.com/spreadsheets/d/1gT4cpHSDQp8A_JIX_5lqTLTwV0xBo_u8u3ZNWALmCLc/edit?usp=sharing)
+to store the `users` data.
 
 Create a new step with the `googlesheet` adaptor for loading the users data into
 your destination GoogleSheet. Configure the step with the following options

--- a/docs/tutorials/http-to-googlesheets.md
+++ b/docs/tutorials/http-to-googlesheets.md
@@ -92,13 +92,13 @@ succeeded, you should see:
 
 ## 3. Configure another Step to transform the data & import your GoogleSheet
 
-Create a new Googlesheet `Credential` using your Google account's email. (Make
-sure this Google user has edit access to the GoogleSheet you want to integrate
-with.)
+Configure an Oauth Client with Google openid using your Google account's email. You can configure it 
+via Project Settings Credentials or on your Credentials via profile menu. 
+The required endpoints for the Google Oauth Client you find it [here](https://accounts.google.com/.well-known/openid-configuration).  
+For mandatory scopes use "openid email profile" (without quotes) and on optional scopes add https://www.googleapis.com/auth/spreadsheets. Make sure your Google user has edit access to the GoogleSheet used on the job.
 
 For this demo, we have created a Googlesheet
-[like this](https://docs.google.com/spreadsheets/d/1gT4cpHSDQp8A_JIX_5lqTLTwV0xBo_u8u3ZNWALmCLc/edit?usp=sharing)
-to store the `users` data.
+[like this](https://docs.google.com/spreadsheets/d/1gT4cpHSDQp8A_JIX_5lqTLTwV0xBo_u8u3ZNWALmCLc/edit?usp=sharing) to store the `users` data.
 
 Create a new step with the `googlesheet` adaptor for loading the users data into
 your destination GoogleSheet. Configure the step with the following options

--- a/docs/tutorials/http-to-googlesheets.md
+++ b/docs/tutorials/http-to-googlesheets.md
@@ -96,7 +96,7 @@ Create a new Googlesheet `Credential` using your Google account's email. (Make
 sure this Google user has edit access to the GoogleSheet you want to integrate
 with.)
 
-For this demo, we have configured the Googlesheet
+For this demo, we have created a Googlesheet
 [like this](https://docs.google.com/spreadsheets/d/1gT4cpHSDQp8A_JIX_5lqTLTwV0xBo_u8u3ZNWALmCLc/edit?usp=sharing)
 to store the `users` data.
 


### PR DESCRIPTION
## Short Description

This PR fixes the URL path for googlesheets adaptors and the general adaptors documentations.

It also provides the information on how to setup a Google Oauth Client used on the demo. 

Refers https://github.com/OpenFn/lightning/issues/2284

## Details

Add any more details that may be relevant to the reviewer. How did you approach
these docs? Are there any parts you struggled with, or that need particularly
careful review?

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
