### PR TITLE
openlmis: add clientId and secret in config documentation

### DIFF
--- a/adaptors/openlmis.md
+++ b/adaptors/openlmis.md
@@ -9,18 +9,14 @@ title: OpenLMIS Adaptor
 
 ## Integration Options
 
-OpenLMIS supports 2 primary integration options with OpenFn:
-
-1. **Rest API:** OpenLMIS has a REST API that enables external services like OpenFn to pull data from OpenLMIS, or push data from external apps to OpenLMIS. This option is suited for scheduled, bulk syncs or workflows that must update data in OpenLMIS with external information. See [functions](/adaptors/packages/openlmis-docs) for more on how to use this adaptor to work with the API.
-
-2. **Webhook:** Webhook or Data Forwarding to push data from OpenLMIS to external systems (see [docs](https://openlmis.org/documentation/)). This option is suited for real-time, event-based data integration.
+**Rest API:** OpenLMIS has a REST API that enables external services like OpenFn to pull data from OpenLMIS, or push data from external apps to OpenLMIS. This option is suited for scheduled, bulk syncs or workflows that must update data in OpenLMIS with external information. See [functions](/adaptors/packages/openlmis-docs) for more on how to use this adaptor to work with the API.
 
 ## Authentication
 
 1. See [OpenLMIS docs](https://openlmis.github.io/openlmis-api/) for the latest on supported authentication methods.
-2. When integrating with OpenLMIS via OpenFn, there is one primary authentication method that is supported: **Basic Authentication**. See this adaptor's [Configuration docs](/adaptors/packages/openlmis-configuration-schema) for more on the required authentication parameters.
+2. The [Auth Service](https://docs.openlmis.org/en/latest/components/authServiceDesign.html0 in OpenLMIS v3 is a stand-alone micro-service that implements **OAuth 2**. See this adaptor's [Configuration docs](/adaptors/packages/openlmis-configuration-schema) for more on the required authentication parameters.
 
-OpenLMIS provides a default `clientId` and `clientSecret` that are required for the authentication. In the below example, we have included these default values that can be used or changed to reflect the current values being used.
+When configuring your credential, `clientId` and `clientSecret` are required inputs for the authentication. If working with a demo environment, OpenLMIS provides default values for these inputs, which should be changed for any production system. In the below example, we have included these default values available.
 
 See platform docs on [managing credentials](/documentation/manage-projects/manage-credentials) for how to configure a credential in OpenFn. If working locally or if using a Raw JSON credential type, then your configuration will look something like this:
 
@@ -29,8 +25,8 @@ See platform docs on [managing credentials](/documentation/manage-projects/manag
   "password": "@some(!)Str0ngp4ss0w0rd",
   "username": "administrator",
   "baseUrl": "https://test.openlmis.org",
-  "clientId": "user-client", // Default value
-  "clientSecret": "changeme" // Default value
+  "clientId": "user-client", // Default value for demo systems
+  "clientSecret": "changeme" // Default value for demo systems
 }
 ```
 

--- a/adaptors/openlmis.md
+++ b/adaptors/openlmis.md
@@ -20,13 +20,17 @@ OpenLMIS supports 2 primary integration options with OpenFn:
 1. See [OpenLMIS docs](https://openlmis.github.io/openlmis-api/) for the latest on supported authentication methods.
 2. When integrating with OpenLMIS via OpenFn, there is one primary authentication method that is supported: **Basic Authentication**. See this adaptor's [Configuration docs](/adaptors/packages/openlmis-configuration-schema) for more on the required authentication parameters.
 
+OpenLMIS provides a default `clientId` and `clientSecret` that are required for the authentication. In the below example, we have included these default values that can be used or changed to reflect the current values being used.
+
 See platform docs on [managing credentials](/documentation/manage-projects/manage-credentials) for how to configure a credential in OpenFn. If working locally or if using a Raw JSON credential type, then your configuration will look something like this:
 
 ```
 {
   "password": "@some(!)Str0ngp4ss0w0rd",
   "username": "administrator",
-  "baseUrl": "https://test.openlmis.org"
+  "baseUrl": "https://test.openlmis.org",
+  "clientId": "user-client", // Default value
+  "clientSecret": "changeme" // Default value
 }
 ```
 


### PR DESCRIPTION
## Short Description
Updated authentication guidance & integration overview

Closes [#655](https://app.zenhub.com/workspaces/implementation-engineering-600030af88f2bb00155d46a5/issues/gh/openfn/docs/655) 

## Details

Add clientId and secret in config documentation (additional required inputs) for openLMIS authentication with default values for demo environment

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
