### PR TITLE
add update trigger for docsite embeddings

### DIFF
--- a/.github/workflows/trigger-embed.yml
+++ b/.github/workflows/trigger-embed.yml
@@ -1,0 +1,22 @@
+name: Trigger Embed Service
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-embed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Embed Service
+        env:
+          PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          curl -X POST https://apollo.staging.openfn.org/services/embed_docsite \
+            -H "Content-Type: application/json" \
+            -d '{
+              "pinecone_api_key": "${{ secrets.PINECONE_API_KEY }}",
+              "openai_api_key": "${{ secrets.OPENAI_API_KEY }}"
+            }'

--- a/.github/workflows/trigger-embed.yml
+++ b/.github/workflows/trigger-embed.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Embed Service
-        env:
+        env: # The API keys are the same as those used by the AI Assistant. There is only one (production) database. 
           PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |


### PR DESCRIPTION
## Short Description

Add workflow action to trigger an update to docsite embeddings in Apollo when the docsite is updated.

## Details

Posts a request to Apollo to trigger the embed_docs service. It requires Pinecone and OpenAI keys (to be added in secrets).

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] Code generation (copilot but not intellisense)
- [x] Learning or fact checking
- [x] Strategy / design
- [ ] Optimisation / refactoring
- [x] Translation / spellchecking / doc gen
- [ ] Other
- [ ] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
