### PR TITLE
Update glossary.md to fix broken link

### DIFF
--- a/docs/get-started/glossary.md
+++ b/docs/get-started/glossary.md
@@ -42,7 +42,7 @@ standards have emerged to make it more straightforward for a new user to
 interact with Platform X's API, by trying to ensure most applications use one of
 a few different formats. That's what an API protocol is. A few of the big names
 here are REST, SOAP, JSON, and GraphQL. Rather than reinvent the wheel,
-[here's a good primer on how protocols differ, their data formats, and why that all matters.](https://frontend-digest.com/beginners-guide-to-apis-protocols-and-data-formats-f80cf7f30425])
+[here's a good primer on how protocols differ, their data formats, and why that all matters.](https://frontend-digest.com/beginners-guide-to-apis-protocols-and-data-formats-f80cf7f30425)
 
 ## Database
 


### PR DESCRIPTION
## Short Description

Fixes link in API protocol definition in Glossary 

## Details

The link had an extra `[` and that led the user to a 404

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [ ] Code generation (copilot but not intellisense)
- [ ] Learning or fact checking
- [ ] Strategy / design
- [ ] Optimisation / refactoring
- [ ] Translation / spellchecking / doc gen
- [ ] Other
- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai#pull-request-templates)
