### PR TITLE
Fix memory usage and state size descriptions in limits.md

### DIFF
--- a/docs/build/limits.md
+++ b/docs/build/limits.md
@@ -14,8 +14,8 @@ for more details.
 | --------------------------- | ------------------------------------------------------------------------- | ------------ | ------- | ------ | ------- | --------- | --------- |
 | Runs                        | Maximum number of runs allowed per month                                  | Unlimited    | 100     | 2,000  | 5,000   | 10,000    | Unlimited |
 | Workflow Execution Duration | Maximum time a workflow can run before being killed                       | Configurable | 60 secs | 5 mins | 20 mins | 30 mins   | 30 mins   |
-| Memory Usage                | Maximum memory allowed per workflow attempt                               | Configurable | 128MB   | 256MB  | 512GB   | 1GB       | 1GB       |
-| State Size                  | Maximum size of state objects inside the runtime VM (25% of Memory Usage) | Dynamic      | 32mb    | 64MB   | 128GB   | 256GB     | 256GB     |
+| Memory Usage                | Maximum memory allowed per workflow attempt                               | Configurable | 128MB   | 256MB  | 512MB   | 1GB       | 1GB       |
+| State Size                  | Maximum size of state objects inside the runtime VM (25% of Memory Usage) | Dynamic      | 32mb    | 64MB   | 128MB   | 256MB     | 256MB     |
 | Dataclip Size               | Maximum size for data clips persisted from run output                     | Configurable | 512KB   | 2MB    | 10MB    | 10MB      | 10MB      |
 | AI Assistant                | Maximum AI tokens available                                               | Configurable | 500K    | 1.5M   | 5M      | 10M       | 10M       |
 | Data Collections (Storage)  | Maximum storage for data collections                                      | Configurable | 1MB     | 5MB    | 10MB    | 50MB      | 50MB      |


### PR DESCRIPTION
Limits were incorrect. Misstated memory limit of 256GB instead of MB was messing up downstream state size limit too. 