### PR TITLE
docs(readme): fix env var, link syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Ensure that the OPENFN_ADAPTORS_REPO env var is set and points to the local
 monorepo.
 
 See
-(github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes)[https://github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes]
+[github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes](https://github.com/OpenFn/adaptors/wiki/How-to-test-docs-changes)
 for more details
 
 ### Build and serve for full-featured testing

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ with watch mode:
 yarn generate-adaptors -w
 ```
 
-Ensure that the OPENFN_ADAPTORS_REPO env var is set and points to the local
+Ensure that the `OPENFN_ADAPTORS_REPO` env var is set and points to the local
 monorepo.
 
 See


### PR DESCRIPTION
## Short Description

Trivial change that fixes syntax in the README

## Details

Per description

## AI Usage

Please disclose how you've used AI in this work (it's cool, we just want to
know!):

- [x] I have not used AI

You can read more details in our
[Responsible AI Policy](https://www.openfn.org/ai)
